### PR TITLE
fix(brand): route Bluesky links through brand config, default to CoSeeker

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -9,12 +9,15 @@ import {
 } from '#/lib/strings/starter-pack'
 import {messages} from '#/locale/locales/en/messages'
 import {klipyUrlToBskyGifUrl} from '#/features/gifPicker/utils'
+import {getActiveBrand} from '../../src/brand/activeBrand'
+import {BSKY_SERVICE} from '../../src/lib/constants'
 import {cleanError} from '../../src/lib/strings/errors'
 import {createFullHandle, makeValidHandle} from '../../src/lib/strings/handles'
 import {enforceLen} from '../../src/lib/strings/helpers'
 import {detectLinkables} from '../../src/lib/strings/rich-text-detection'
 import {shortenLinks} from '../../src/lib/strings/rich-text-manip'
 import {
+  BSKY_APP_HOST,
   makeRecordUri,
   toNiceDomain,
   toShareUrl,
@@ -234,10 +237,16 @@ describe('toNiceDomain', () => {
   const inputs = [
     'https://example.com/index.html',
     'https://bsky.app',
-    'https://bsky.social',
+    // The active brand's PDS host resolves to its friendly name.
+    BSKY_SERVICE,
     '#123123123',
   ]
-  const outputs = ['example.com', 'bsky.app', 'Bluesky Social', '#123123123']
+  const outputs = [
+    'example.com',
+    'bsky.app',
+    getActiveBrand().pds.name,
+    '#123123123',
+  ]
 
   it("displays the url's host in a easily readable manner", () => {
     for (let i = 0; i < inputs.length; i++) {
@@ -275,8 +284,8 @@ describe('toShareUrl', () => {
   const inputs = ['https://bsky.app', '/3jk7x4irgv52r', 'item/test/123']
   const outputs = [
     'https://bsky.app',
-    'https://bsky.app/3jk7x4irgv52r',
-    'https://bsky.app/item/test/123',
+    `${BSKY_APP_HOST}/3jk7x4irgv52r`,
+    `${BSKY_APP_HOST}/item/test/123`,
   ]
 
   it('appends https, when not present', () => {

--- a/brands/bluesky/brand.ts
+++ b/brands/bluesky/brand.ts
@@ -1,6 +1,7 @@
 import {DEFAULT_PALETTE, DEFAULT_SUBDUED_PALETTE} from '@bsky.app/alf'
 
 import {type Brand} from '#/brand/types'
+import {DEFAULT_BRAND_PAGE_LINKS} from '../shared/links'
 import nativeConfig from './brand.js'
 
 /**
@@ -42,7 +43,11 @@ const brand: Brand = {
   ],
 
   links: {
+    // Spread the coseeker.org defaults, then override every brand-page link
+    // back to Bluesky's own URLs so the Bluesky brand is unchanged from upstream.
+    ...DEFAULT_BRAND_PAGE_LINKS,
     helpDesk: 'https://blueskyweb.zendesk.com/hc/en-us',
+    feedbackForm: 'https://blueskyweb.zendesk.com/hc/en-us/requests/new',
     statusPage: 'https://status.bsky.app/',
     download: 'https://bsky.app/download',
     embedService: 'https://embed.bsky.app',
@@ -54,6 +59,7 @@ const brand: Brand = {
     community: 'https://bsky.social/about/support/community-guidelines',
     communityDeprecated:
       'https://bsky.social/about/support/community-guidelines-deprecated',
+    copyright: 'https://bsky.social/about/support/copyright',
   },
 
   blogUrls: {

--- a/brands/coseeker/brand.ts
+++ b/brands/coseeker/brand.ts
@@ -2,6 +2,7 @@ import {type Palette} from '@bsky.app/alf'
 
 import {type Brand} from '#/brand/types'
 import {EARTH_MARK_SVG} from '../shared/earthMark.svg'
+import {DEFAULT_BRAND_PAGE_LINKS} from '../shared/links'
 import nativeConfig from './brand.js'
 import {COSEEKER_WORDMARK_SVG} from './wordmark.svg'
 
@@ -232,17 +233,17 @@ const brand: Brand = {
   ],
 
   links: {
-    helpDesk: 'https://blueskyweb.zendesk.com/hc/en-us',
+    // Brand-page links (help, feedback, tos, privacy, community, copyright)
+    // default to coseeker.org via DEFAULT_BRAND_PAGE_LINKS. Infra links below
+    // intentionally still point at the shared Bluesky AppView services that
+    // CoSeeker's PDS relies on.
+    ...DEFAULT_BRAND_PAGE_LINKS,
     statusPage: 'https://status.bsky.app/',
     download: 'https://bsky.app/download',
     embedService: 'https://embed.bsky.app',
     gifService: 'https://gifs.bsky.app',
     videoService: 'https://video.bsky.app',
     videoServiceDid: 'did:web:video.bsky.app',
-    tos: 'https://coseeker.org/terms.html',
-    privacy: 'https://coseeker.org/privacy.html',
-    community: 'https://coseeker.org/guidelines.html',
-    communityDeprecated: 'https://coseeker.org/guidelines.html',
   },
 
   blogUrls: {

--- a/brands/k4m2a/brand.js
+++ b/brands/k4m2a/brand.js
@@ -26,8 +26,8 @@ const brand = {
   primaryColor: '#000000',
   splashColor: '#FFFFFF',
   splashColorDark: '#000000',
-  // TODO: deep-link / universal-link host (no scheme prefix)
-  webHost: 'TODO.example.com',
+  // Deep-link / universal-link host (no scheme prefix)
+  webHost: 'k4m2a.app',
   associatedDomains: [
     // TODO: applinks for Universal Links + appclips entries if used
     // 'applinks:TODO.example.com',

--- a/brands/k4m2a/brand.ts
+++ b/brands/k4m2a/brand.ts
@@ -2,6 +2,7 @@ import {type Palette} from '@bsky.app/alf'
 
 import {type Brand} from '#/brand/types'
 import {EARTH_MARK_SVG} from '../shared/earthMark.svg'
+import {DEFAULT_BRAND_PAGE_LINKS} from '../shared/links'
 import nativeConfig from './brand.js'
 
 /**
@@ -285,17 +286,15 @@ const brand: Brand = {
   ],
 
   links: {
-    helpDesk: 'https://blueskyweb.zendesk.com/hc/en-us',
+    // Brand-page links default to coseeker.org (k4m2a accounts live on the
+    // coseeker.org PDS). Infra links stay on the shared Bluesky AppView.
+    ...DEFAULT_BRAND_PAGE_LINKS,
     statusPage: 'https://status.bsky.app/',
     download: 'https://bsky.app/download',
     embedService: 'https://embed.bsky.app',
     gifService: 'https://gifs.bsky.app',
     videoService: 'https://video.bsky.app',
     videoServiceDid: 'did:web:video.bsky.app',
-    tos: 'https://coseeker.org/terms.html',
-    privacy: 'https://coseeker.org/privacy.html',
-    community: 'https://coseeker.org/guidelines.html',
-    communityDeprecated: 'https://coseeker.org/guidelines.html',
   },
 
   blogUrls: {

--- a/brands/mdparivaar/brand.js
+++ b/brands/mdparivaar/brand.js
@@ -23,8 +23,8 @@ const brand = {
   primaryColor: '#CD7233',
   splashColor: '#FFFFFF',
   splashColorDark: '#150D0A',
-  // TODO: deep-link / universal-link host
-  webHost: 'TODO.mdparivaar.example',
+  // Deep-link / universal-link host
+  webHost: 'mdparivaar.com',
   associatedDomains: [
     // TODO: 'applinks:TODO.mdparivaar.example',
   ],

--- a/brands/mdparivaar/brand.ts
+++ b/brands/mdparivaar/brand.ts
@@ -1,6 +1,7 @@
 import {DEFAULT_PALETTE, DEFAULT_SUBDUED_PALETTE} from '@bsky.app/alf'
 
 import {type Brand} from '#/brand/types'
+import {DEFAULT_BRAND_PAGE_LINKS} from '../shared/links'
 import nativeConfig from './brand.js'
 import {MD_ICON_SVG} from './logoIcon.svg'
 
@@ -114,17 +115,15 @@ const brand: Brand = {
   ],
 
   links: {
-    helpDesk: 'https://blueskyweb.zendesk.com/hc/en-us',
+    // Brand-page links default to coseeker.org (mdparivaar accounts live on the
+    // coseeker.org PDS). Infra links stay on the shared Bluesky AppView.
+    ...DEFAULT_BRAND_PAGE_LINKS,
     statusPage: 'https://status.bsky.app/',
     download: 'https://bsky.app/download',
     embedService: 'https://embed.bsky.app',
     gifService: 'https://gifs.bsky.app',
     videoService: 'https://video.bsky.app',
     videoServiceDid: 'did:web:video.bsky.app',
-    tos: 'https://coseeker.org/terms.html',
-    privacy: 'https://coseeker.org/privacy.html',
-    community: 'https://coseeker.org/guidelines.html',
-    communityDeprecated: 'https://coseeker.org/guidelines.html',
   },
 
   blogUrls: {

--- a/brands/shared/links.ts
+++ b/brands/shared/links.ts
@@ -1,0 +1,16 @@
+/**
+ * Default brand-page links. These point at coseeker.org (the default
+ * community's PDS host) the same way Bluesky's point at bsky.social. Brands
+ * spread this into their `links` and override individual entries as needed
+ * (see `brands/bluesky/brand.ts`). The fallback for any brand that does not
+ * override is coseeker.org.
+ */
+export const DEFAULT_BRAND_PAGE_LINKS = {
+  helpDesk: 'https://coseeker.org/help.html',
+  feedbackForm: 'https://forms.gle/XnFKKop2tExwZbUe6',
+  tos: 'https://coseeker.org/terms.html',
+  privacy: 'https://coseeker.org/privacy.html',
+  community: 'https://coseeker.org/guidelines.html',
+  communityDeprecated: 'https://coseeker.org/guidelines.html',
+  copyright: 'https://coseeker.org/guidelines.html',
+}

--- a/src/brand/registry.ts
+++ b/src/brand/registry.ts
@@ -15,7 +15,7 @@ export const brands: Record<string, Brand> = {
   mdparivaar,
 }
 
-export const DEFAULT_BRAND_ID = 'bluesky'
+export const DEFAULT_BRAND_ID = 'coseeker'
 
 export function getBrandById(id: string | undefined): Brand {
   if (id && brands[id]) return brands[id]

--- a/src/brand/types.ts
+++ b/src/brand/types.ts
@@ -38,6 +38,12 @@ export type Brand = BrandConfig & {
 
   links: {
     helpDesk: string
+    /**
+     * Where the "Feedback" / "Contact support" affordances point. Zendesk
+     * forms (e.g. Bluesky) get the email/handle prefill query params appended
+     * by `FEEDBACK_FORM_URL`; other brands (e.g. a Google Form) are used as-is.
+     */
+    feedbackForm: string
     statusPage: string
     download: string
     embedService: string
@@ -48,6 +54,7 @@ export type Brand = BrandConfig & {
     privacy: string
     community: string
     communityDeprecated: string
+    copyright: string
   }
 
   blogUrls: {

--- a/src/components/PolicyUpdateOverlay/updates/202508/index.tsx
+++ b/src/components/PolicyUpdateOverlay/updates/202508/index.tsx
@@ -4,6 +4,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
+import {webLinks} from '#/lib/constants'
 import {useA11y} from '#/state/a11y'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
@@ -27,27 +28,27 @@ export function Content({state}: {state: PolicyUpdateState}) {
   const links = {
     terms: {
       overridePresentation: false,
-      to: `https://bsky.social/about/support/tos`,
+      to: webLinks.tos,
       label: _(msg`Terms of Service`),
     },
     privacy: {
       overridePresentation: false,
-      to: `https://bsky.social/about/support/privacy-policy`,
+      to: webLinks.privacy,
       label: _(msg`Privacy Policy`),
     },
     copyright: {
       overridePresentation: false,
-      to: `https://bsky.social/about/support/copyright`,
+      to: webLinks.copyright,
       label: _(msg`Copyright Policy`),
     },
     guidelines: {
       overridePresentation: false,
-      to: `https://bsky.social/about/support/community-guidelines`,
+      to: webLinks.community,
       label: _(msg`Community Guidelines`),
     },
     blog: {
       overridePresentation: false,
-      to: `https://bsky.social/about/blog/08-14-2025-updated-terms-and-policies`,
+      to: webLinks.tos,
       label: _(msg`Our blog post`),
     },
   }

--- a/src/components/dialogs/BirthDateSettings.tsx
+++ b/src/components/dialogs/BirthDateSettings.tsx
@@ -2,6 +2,7 @@ import {useCallback, useMemo, useState} from 'react'
 import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
+import {webLinks} from '#/lib/constants'
 import {useCleanError} from '#/lib/hooks/useCleanError'
 import {isAppPassword} from '#/lib/jwt'
 import {getAge, getDateAgo} from '#/lib/strings/time'
@@ -172,9 +173,7 @@ function BirthdayInner({
         <Admonition type="error">
           <Trans>
             You must be at least 13 years old to use Bluesky. Read our{' '}
-            <SimpleInlineLinkText
-              to="https://bsky.social/about/support/tos"
-              label={l`Terms of Service`}>
+            <SimpleInlineLinkText to={webLinks.tos} label={l`Terms of Service`}>
               Terms of Service
             </SimpleInlineLinkText>{' '}
             for more information.

--- a/src/components/dialogs/nuxs/InitialVerificationAnnouncement.tsx
+++ b/src/components/dialogs/nuxs/InitialVerificationAnnouncement.tsx
@@ -15,6 +15,7 @@ import {VerifierCheck} from '#/components/icons/VerifierCheck'
 import {Link} from '#/components/Link'
 import {Span, Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
+import {getActiveBrand} from '#/brand/activeBrand'
 import {IS_NATIVE} from '#/env'
 
 export function InitialVerificationAnnouncement() {
@@ -154,23 +155,25 @@ export function InitialVerificationAnnouncement() {
           </View>
 
           <View style={[a.w_full, a.gap_md]}>
-            <Link
-              overridePresentation
-              to={urls.website.blog.initialVerificationAnnouncement}
-              label={_(msg`Read blog post`)}
-              size="small"
-              variant="solid"
-              color="primary"
-              style={[a.justify_center, a.w_full]}
-              onPress={() => {
-                ax.metric('verification:learn-more', {
-                  location: 'initialAnnouncementeNux',
-                })
-              }}>
-              <ButtonText>
-                <Trans>Read blog post</Trans>
-              </ButtonText>
-            </Link>
+            {getActiveBrand().id === 'bluesky' && (
+              <Link
+                overridePresentation
+                to={urls.website.blog.initialVerificationAnnouncement}
+                label={_(msg`Read blog post`)}
+                size="small"
+                variant="solid"
+                color="primary"
+                style={[a.justify_center, a.w_full]}
+                onPress={() => {
+                  ax.metric('verification:learn-more', {
+                    location: 'initialAnnouncementeNux',
+                  })
+                }}>
+                <ButtonText>
+                  <Trans>Read blog post</Trans>
+                </ButtonText>
+              </Link>
+            )}
             {IS_NATIVE && (
               <Button
                 label={_(msg`Close`)}

--- a/src/components/moderation/ReportDialog/const.ts
+++ b/src/components/moderation/ReportDialog/const.ts
@@ -4,9 +4,12 @@ import {
 } from '@atproto/api'
 
 import {type ParsedReportSubject} from '#/components/moderation/ReportDialog/types'
+import {getActiveBrand} from '#/brand/activeBrand'
 
-export const DMCA_LINK = 'https://bsky.social/about/support/copyright'
-export const SUPPORT_PAGE = 'https://bsky.social/about/support'
+const brand = getActiveBrand()
+
+export const DMCA_LINK = brand.links.copyright
+export const SUPPORT_PAGE = brand.links.helpDesk
 
 export const NEW_TO_OLD_REASON_MAPPING: Record<string, string> = {}
 

--- a/src/components/verification/VerificationsDialog.tsx
+++ b/src/components/verification/VerificationsDialog.tsx
@@ -21,6 +21,7 @@ import {Text} from '#/components/Typography'
 import {type FullVerificationState} from '#/components/verification'
 import {VerificationRemovePrompt} from '#/components/verification/VerificationRemovePrompt'
 import {useAnalytics} from '#/analytics'
+import {getActiveBrand} from '#/brand/activeBrand'
 import type * as bsky from '#/types/bsky'
 
 export {useDialogControl} from '#/components/Dialog'
@@ -146,28 +147,30 @@ function Inner({
             <Trans>Close</Trans>
           </ButtonText>
         </Button>
-        <Link
-          overridePresentation
-          to={urls.website.blog.initialVerificationAnnouncement}
-          label={_(
-            msg({
-              message: `Learn more about verification on Bluesky`,
-              context: `english-only-resource`,
-            }),
-          )}
-          size="small"
-          variant="solid"
-          color="secondary"
-          style={[a.justify_center]}
-          onPress={() => {
-            ax.metric('verification:learn-more', {
-              location: 'verificationsDialog',
-            })
-          }}>
-          <ButtonText>
-            <Trans context="english-only-resource">Learn more</Trans>
-          </ButtonText>
-        </Link>
+        {getActiveBrand().id === 'bluesky' && (
+          <Link
+            overridePresentation
+            to={urls.website.blog.initialVerificationAnnouncement}
+            label={_(
+              msg({
+                message: `Learn more about verification on Bluesky`,
+                context: `english-only-resource`,
+              }),
+            )}
+            size="small"
+            variant="solid"
+            color="secondary"
+            style={[a.justify_center]}
+            onPress={() => {
+              ax.metric('verification:learn-more', {
+                location: 'verificationsDialog',
+              })
+            }}>
+            <ButtonText>
+              <Trans context="english-only-resource">Learn more</Trans>
+            </ButtonText>
+          </Link>
+        )}
       </View>
 
       <Dialog.Close />

--- a/src/components/verification/VerifierDialog.tsx
+++ b/src/components/verification/VerifierDialog.tsx
@@ -15,6 +15,7 @@ import {Link} from '#/components/Link'
 import {Text} from '#/components/Typography'
 import {type FullVerificationState} from '#/components/verification'
 import {useAnalytics} from '#/analytics'
+import {getActiveBrand} from '#/brand/activeBrand'
 import type * as bsky from '#/types/bsky'
 
 export {useDialogControl} from '#/components/Dialog'
@@ -114,27 +115,29 @@ function Inner({
             a.justify_end,
             gtMobile ? [a.flex_row, a.justify_end] : [a.flex_col],
           ]}>
-          <Link
-            overridePresentation
-            to={urls.website.blog.initialVerificationAnnouncement}
-            label={_(
-              msg({
-                message: `Learn more about verification on Bluesky`,
-                context: `english-only-resource`,
-              }),
-            )}
-            size="small"
-            color="primary"
-            style={[a.justify_center]}
-            onPress={() => {
-              ax.metric('verification:learn-more', {
-                location: 'verifierDialog',
-              })
-            }}>
-            <ButtonText>
-              <Trans context="english-only-resource">Learn more</Trans>
-            </ButtonText>
-          </Link>
+          {getActiveBrand().id === 'bluesky' && (
+            <Link
+              overridePresentation
+              to={urls.website.blog.initialVerificationAnnouncement}
+              label={_(
+                msg({
+                  message: `Learn more about verification on Bluesky`,
+                  context: `english-only-resource`,
+                }),
+              )}
+              size="small"
+              color="primary"
+              style={[a.justify_center]}
+              onPress={() => {
+                ax.metric('verification:learn-more', {
+                  location: 'verifierDialog',
+                })
+              }}>
+              <ButtonText>
+                <Trans context="english-only-resource">Learn more</Trans>
+              </ButtonText>
+            </Link>
+          )}
           <Button
             label={_(msg`Close dialog`)}
             size="small"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -43,7 +43,6 @@ export const DISCOVER_DEBUG_DIDS: Record<string, true> = {
   'did:plc:2dzyut5lxna5ljiaasgeuffz': true, // darrin.bsky.team
 }
 
-const BASE_FEEDBACK_FORM_URL = `${HELP_DESK_URL}/requests/new`
 export function FEEDBACK_FORM_URL({
   email,
   handle,
@@ -51,8 +50,11 @@ export function FEEDBACK_FORM_URL({
   email?: string
   handle?: string
 }): string {
-  let str = BASE_FEEDBACK_FORM_URL
-  if (email) {
+  let str = brand.links.feedbackForm
+  // The email/handle prefill query params are specific to the Zendesk request
+  // form. Brands with a non-Zendesk feedback destination (e.g. a Google Form)
+  // are used as-is.
+  if (email && str.includes('zendesk')) {
     str += `?tf_anonymous_requester_email=${encodeURIComponent(email)}`
     if (handle) {
       str += `&tf_17205412673421=${encodeURIComponent(handle)}`
@@ -251,4 +253,5 @@ export const webLinks = {
   privacy: brand.links.privacy,
   community: brand.links.community,
   communityDeprecated: brand.links.communityDeprecated,
+  copyright: brand.links.copyright,
 }

--- a/src/lib/hooks/useCreateSupportLink.ts
+++ b/src/lib/hooks/useCreateSupportLink.ts
@@ -3,9 +3,10 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 
 import {useSession} from '#/state/session'
+import {getActiveBrand} from '#/brand/activeBrand'
 
-export const ZENDESK_SUPPORT_URL =
-  'https://blueskyweb.zendesk.com/hc/requests/new'
+const SUPPORT_FORM_URL = getActiveBrand().links.feedbackForm
+const IS_ZENDESK_FORM = SUPPORT_FORM_URL.includes('zendesk')
 
 export enum SupportCode {
   AA_DID = 'AA_DID',
@@ -21,14 +22,17 @@ export function useCreateSupportLink() {
 
   return useCallback(
     ({code, email}: {code: SupportCode; email?: string}) => {
-      const url = new URL(ZENDESK_SUPPORT_URL)
-      if (currentAccount) {
+      const url = new URL(SUPPORT_FORM_URL)
+      // The prefill params are specific to the Zendesk request form. Brands
+      // with a non-Zendesk feedback destination (e.g. a Google Form) are used
+      // as-is.
+      if (IS_ZENDESK_FORM && currentAccount) {
         url.search = new URLSearchParams({
           tf_anonymous_requester_email: email || currentAccount.email || '', // email will be defined
           tf_description:
             `[Code: ${code}] — ` + _(msg`Please write your message below:`),
           /**
-           * Custom field specific to {@link ZENDESK_SUPPORT_URL} form
+           * Custom field specific to the Zendesk support form.
            */
           tf_17205412673421: currentAccount.handle + ` (${currentAccount.did})`,
         }).toString()

--- a/src/lib/routes/links.ts
+++ b/src/lib/routes/links.ts
@@ -1,6 +1,7 @@
 import {type AppBskyGraphDefs, AtUri} from '@atproto/api'
 
 import {isInvalidHandle} from '#/lib/strings/handles'
+import {BSKY_APP_HOST} from '#/lib/strings/url-helpers'
 
 export function makeProfileLink(
   info: {
@@ -19,8 +20,8 @@ export function makeProfileLink(
 export function makeCustomFeedLink(
   did: string,
   rkey: string,
-  segment?: string | undefined,
-  feedCacheKey?: 'discover' | 'explore' | undefined,
+  segment?: string,
+  feedCacheKey?: 'discover' | 'explore',
 ) {
   return (
     [`/profile`, did, 'feed', rkey, ...(segment ? [segment] : [])].join('/') +
@@ -50,9 +51,9 @@ export function makeStarterPackLink(
   rkey?: string,
 ) {
   if (typeof starterPackOrName === 'string') {
-    return `https://bsky.app/start/${starterPackOrName}/${rkey}`
+    return `${BSKY_APP_HOST}/start/${starterPackOrName}/${rkey}`
   } else {
     const uriRkey = new AtUri(starterPackOrName.uri).rkey
-    return `https://bsky.app/start/${starterPackOrName.creator.handle}/${uriRkey}`
+    return `${BSKY_APP_HOST}/start/${starterPackOrName.creator.handle}/${uriRkey}`
   }
 }

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -8,12 +8,33 @@ import {startUriToStarterPackUri} from '#/lib/strings/starter-pack'
 import {logger} from '#/logger'
 import {getActiveBrand} from '#/brand/activeBrand'
 
-export const BSKY_APP_HOST = 'https://bsky.app'
+const activeBrand = getActiveBrand()
+
+/** Web host for the active brand, e.g. `coseeker.com` (Bluesky: `bsky.app`). */
+const BRAND_WEB_HOST = activeBrand.webHost
+/** PDS host for the active brand, e.g. `coseeker.org` (Bluesky: `bsky.social`). */
+const BRAND_PDS_HOST = (() => {
+  try {
+    return new URL(activeBrand.pds.serviceUrl).host
+  } catch {
+    return ''
+  }
+})()
+
+export const BSKY_APP_HOST = `https://${BRAND_WEB_HOST}`
+
+function escapeForRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 const BSKY_TRUSTED_HOSTS = [
   'bsky\\.app',
   'bsky\\.social',
   'blueskyweb\\.xyz',
   'blueskyweb\\.zendesk\\.com',
+  // Trust the active brand's own web + PDS hosts (deduped against the literals
+  // above by the regex alternation; harmless if they overlap).
+  ...[BRAND_WEB_HOST, BRAND_PDS_HOST].filter(Boolean).map(escapeForRegex),
   ...(__DEV__ ? ['localhost:19006', 'localhost:8100'] : []),
 ]
 
@@ -81,7 +102,7 @@ export function toShortUrl(url: string): string {
 
 export function toShareUrl(url: string): string {
   if (!url.startsWith('https')) {
-    const urlp = new URL('https://bsky.app')
+    const urlp = new URL(BSKY_APP_HOST)
     urlp.pathname = url
     url = urlp.toString()
   }
@@ -93,7 +114,11 @@ export function toBskyAppUrl(url: string): string {
 }
 
 export function isBskyAppUrl(url: string): boolean {
-  return url.startsWith('https://bsky.app/')
+  // Treat both the active brand's host and bsky.app as internal: posts on the
+  // shared atproto network commonly carry bsky.app links regardless of brand.
+  return (
+    url.startsWith(`${BSKY_APP_HOST}/`) || url.startsWith('https://bsky.app/')
+  )
 }
 
 export function isRelativeUrl(url: string): boolean {
@@ -102,7 +127,9 @@ export function isRelativeUrl(url: string): boolean {
 
 export function isBskyRSSUrl(url: string): boolean {
   return (
-    (url.startsWith('https://bsky.app/') || isRelativeUrl(url)) &&
+    (url.startsWith(`${BSKY_APP_HOST}/`) ||
+      url.startsWith('https://bsky.app/') ||
+      isRelativeUrl(url)) &&
     /\/rss\/?$/.test(url)
   )
 }

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -14,6 +14,7 @@ import {shareUrl} from '#/lib/sharing'
 import {cleanError} from '#/lib/strings/errors'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {enforceLen} from '#/lib/strings/helpers'
+import {BSKY_APP_HOST} from '#/lib/strings/url-helpers'
 import {useSearchPostsQuery} from '#/state/queries/search-posts'
 import {useSession} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
@@ -68,7 +69,7 @@ export default function HashtagScreen({
   }, [author])
 
   const onShare = useCallback(() => {
-    const url = new URL('https://bsky.app')
+    const url = new URL(BSKY_APP_HOST)
     url.pathname = `/hashtag/${decodeURIComponent(tag)}`
     if (author) {
       url.searchParams.set('author', author)

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -6,6 +6,7 @@ import {Trans, useLingui} from '@lingui/react/macro'
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {shareUrl} from '#/lib/sharing'
+import {BSKY_APP_HOST} from '#/lib/strings/url-helpers'
 import {useCreateJoinLink} from '#/state/queries/messages/create-join-link'
 import {useDisableJoinLink} from '#/state/queries/messages/disable-join-link'
 import {useEditJoinLink} from '#/state/queries/messages/edit-join-link'
@@ -267,8 +268,8 @@ export function InviteLinkDialog({
       break
     case Step.MANAGE: {
       const joinLinkURI = joinLink?.code
-        ? `https://bsky.app/chat/${joinLink.code}`
-        : 'https://bsky.app/chat'
+        ? `${BSKY_APP_HOST}/chat/${joinLink.code}`
+        : `${BSKY_APP_HOST}/chat`
       const createdAt = joinLink ? new Date(joinLink.createdAt) : null
       const currentOptionName = joinLink
         ? `${joinLink.joinRule}${joinLink.requireApproval ? ':requireApproval' : ''}`

--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -10,6 +10,7 @@ import {
   type CommonNavigatorParams,
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
+import {BSKY_APP_HOST} from '#/lib/strings/url-helpers'
 import {logger} from '#/logger'
 import {useIsBirthdateUpdateAllowed} from '#/state/birthdate'
 import {useRemoveLabelersMutation} from '#/state/queries/labeler'
@@ -45,6 +46,7 @@ import {GlobalLabelPreference} from '#/components/moderation/LabelPreference'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {useAgeAssurance} from '#/ageAssurance'
+import {useBrand} from '#/brand/context'
 import {IS_IOS} from '#/env'
 
 function ErrorState({error}: {error: string}) {
@@ -159,6 +161,7 @@ export function ModerationScreenInner({
 }) {
   const {_} = useLingui()
   const t = useTheme()
+  const brand = useBrand()
   const {gtMobile} = useBreakpoints()
   const {mutedWordsDialogControl} = useGlobalDialogsControlContext()
   const {
@@ -412,14 +415,14 @@ export function ModerationScreenInner({
                     <Trans>
                       Adult content can only be enabled via the Web at{' '}
                       <InlineLinkText
-                        label={_(msg`The Bluesky web application`)}
+                        label={_(msg`The ${brand.name} web application`)}
                         to=""
                         onPress={evt => {
                           evt.preventDefault()
-                          Linking.openURL('https://bsky.app/')
+                          Linking.openURL(`${BSKY_APP_HOST}/`)
                           return false
                         }}>
-                        bsky.app
+                        {brand.webHost}
                       </InlineLinkText>
                       .
                     </Trans>

--- a/src/screens/Settings/AboutSettings.tsx
+++ b/src/screens/Settings/AboutSettings.tsx
@@ -8,7 +8,7 @@ import {Trans} from '@lingui/react/macro'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 import {useMutation} from '@tanstack/react-query'
 
-import {STATUS_PAGE_URL} from '#/lib/constants'
+import {STATUS_PAGE_URL, webLinks} from '#/lib/constants'
 import {type CommonNavigatorParams} from '#/lib/routes/types'
 import * as SettingsList from '#/screens/Settings/components/SettingsList'
 import {Atom_Stroke2_Corner0_Rounded as AtomIcon} from '#/components/icons/Atom'
@@ -83,7 +83,7 @@ export function AboutSettingsScreen({}: Props) {
       <Layout.Content>
         <SettingsList.Container>
           <SettingsList.LinkItem
-            to="https://bsky.social/about/support/tos"
+            to={webLinks.tos}
             label={_(msg`Terms of Service`)}>
             <SettingsList.ItemIcon icon={NewspaperIcon} />
             <SettingsList.ItemText>
@@ -91,7 +91,7 @@ export function AboutSettingsScreen({}: Props) {
             </SettingsList.ItemText>
           </SettingsList.LinkItem>
           <SettingsList.LinkItem
-            to="https://bsky.social/about/support/privacy-policy"
+            to={webLinks.privacy}
             label={_(msg`Privacy Policy`)}>
             <SettingsList.ItemIcon icon={NewspaperIcon} />
             <SettingsList.ItemText>

--- a/src/screens/Signup/StepInfo/Policies.tsx
+++ b/src/screens/Signup/StepInfo/Policies.tsx
@@ -24,8 +24,17 @@ export const Policies = ({
     return <View />
   }
 
-  const tos = validWebLink(serviceDescription.links?.termsOfService)
-  const pp = validWebLink(serviceDescription.links?.privacyPolicy)
+  // When the brand only allows signups on its own PDS, the brand's legal pages
+  // are the source of truth - the PDS `describeServer` response may still carry
+  // upstream (e.g. Bluesky) links, which would otherwise leak through here.
+  // Brands that allow foreign-PDS signup keep showing the chosen PDS's links.
+  const preferBrandLinks = !brand.features.allowForeignPdsSignup
+  const tos = preferBrandLinks
+    ? brand.links.tos
+    : validWebLink(serviceDescription.links?.termsOfService)
+  const pp = preferBrandLinks
+    ? brand.links.privacy
+    : validWebLink(serviceDescription.links?.privacyPolicy)
 
   if (!tos && !pp) {
     return (

--- a/src/screens/Takendown.tsx
+++ b/src/screens/Takendown.tsx
@@ -12,6 +12,7 @@ import {countGraphemes} from 'unicode-segmenter/grapheme'
 import {
   BLUESKY_MOD_SERVICE_HEADERS,
   MAX_REPORT_REASON_GRAPHEME_LENGTH,
+  webLinks,
 } from '#/lib/constants'
 import {cleanError} from '#/lib/strings/errors'
 import {useAgent, useSession, useSessionApi} from '#/state/session'
@@ -211,7 +212,7 @@ export function Takendown() {
                   Your account was found to be in violation of the{' '}
                   <SimpleInlineLinkText
                     label={_(msg`Bluesky Social Terms of Service`)}
-                    to="https://bsky.social/about/support/tos"
+                    to={webLinks.tos}
                     style={[a.text_md, a.leading_snug]}>
                     Bluesky Social Terms of Service
                   </SimpleInlineLinkText>

--- a/src/screens/Topic.tsx
+++ b/src/screens/Topic.tsx
@@ -12,6 +12,7 @@ import {type CommonNavigatorParams} from '#/lib/routes/types'
 import {shareUrl} from '#/lib/sharing'
 import {cleanError} from '#/lib/strings/errors'
 import {enforceLen} from '#/lib/strings/helpers'
+import {BSKY_APP_HOST} from '#/lib/strings/url-helpers'
 import {useSearchPostsQuery} from '#/state/queries/search-posts'
 import {Pager} from '#/view/com/pager/Pager'
 import {TabBar} from '#/view/com/pager/TabBar'
@@ -42,7 +43,7 @@ export default function TopicScreen({
   }, [topic])
 
   const onShare = useCallback(() => {
-    const url = new URL('https://bsky.app')
+    const url = new URL(BSKY_APP_HOST)
     url.pathname = `/topic/${topic}`
     shareUrl(url.toString())
   }, [topic])

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -162,6 +162,7 @@ export const SplashScreen = ({
 function Footer() {
   const t = useTheme()
   const {_} = useLingui()
+  const brand = getActiveBrand()
 
   return (
     <View
@@ -179,23 +180,28 @@ function Footer() {
         a.flex_1,
         t.atoms.border_contrast_medium,
       ]}>
-      <InlineLinkText
-        label={_(msg`Learn more about Bluesky`)}
-        to="https://bsky.social">
-        <Trans>Business</Trans>
-      </InlineLinkText>
-      <InlineLinkText
-        label={_(msg`Read the Bluesky blog`)}
-        to="https://bsky.social/about/blog">
-        <Trans>Blog</Trans>
-      </InlineLinkText>
-      <InlineLinkText
-        label={_(msg`See jobs at Bluesky`)}
-        to="https://bsky.social/about/join">
-        <Trans comment="Link to a page with job openings at Bluesky">
-          Jobs
-        </Trans>
-      </InlineLinkText>
+      {/* Bluesky-corporate links have no equivalent for other brands. */}
+      {brand.id === 'bluesky' && (
+        <>
+          <InlineLinkText
+            label={_(msg`Learn more about Bluesky`)}
+            to="https://bsky.social">
+            <Trans>Business</Trans>
+          </InlineLinkText>
+          <InlineLinkText
+            label={_(msg`Read the Bluesky blog`)}
+            to="https://bsky.social/about/blog">
+            <Trans>Blog</Trans>
+          </InlineLinkText>
+          <InlineLinkText
+            label={_(msg`See jobs at Bluesky`)}
+            to="https://bsky.social/about/join">
+            <Trans comment="Link to a page with job openings at Bluesky">
+              Jobs
+            </Trans>
+          </InlineLinkText>
+        </>
+      )}
 
       <View style={a.flex_1} />
 

--- a/src/view/com/composer/drafts/state/api.ts
+++ b/src/view/com/composer/drafts/state/api.ts
@@ -9,6 +9,7 @@ import {getDeviceName} from '#/lib/deviceName'
 import {getImageDim} from '#/lib/media/manip'
 import {mimeToExt} from '#/lib/media/video/util'
 import {shortenLinks} from '#/lib/strings/rich-text-manip'
+import {BSKY_APP_HOST} from '#/lib/strings/url-helpers'
 import {type ComposerImage} from '#/state/gallery'
 import {threadgateAllowUISettingToAllowRecordValue} from '#/state/queries/threadgate/util'
 import {createPublicAgent} from '#/state/session/agent'
@@ -548,7 +549,7 @@ export async function draftToComposerPosts(
       if (post.embedRecords && post.embedRecords.length > 0) {
         const record = post.embedRecords[0]
         const urip = new AtUri(record.record.uri)
-        const url = `https://bsky.app/profile/${urip.host}/post/${urip.rkey}`
+        const url = `${BSKY_APP_HOST}/profile/${urip.host}/post/${urip.rkey}`
         embed.quote = {type: 'link', uri: url}
       }
 

--- a/src/view/screens/CommunityGuidelines.tsx
+++ b/src/view/screens/CommunityGuidelines.tsx
@@ -3,6 +3,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
+import {webLinks} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {
   type CommonNavigatorParams,
@@ -33,8 +34,8 @@ export const CommunityGuidelinesScreen = (_props: Props) => {
               The Community Guidelines have been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://bsky.social/about/support/community-guidelines"
-                text="bsky.social/about/support/community-guidelines"
+                href={webLinks.community}
+                text={webLinks.community.replace(/^https?:\/\//, '')}
               />
             </Trans>
           </Text>

--- a/src/view/screens/CopyrightPolicy.tsx
+++ b/src/view/screens/CopyrightPolicy.tsx
@@ -3,6 +3,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
+import {webLinks} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {
   type CommonNavigatorParams,
@@ -30,8 +31,8 @@ export const CopyrightPolicyScreen = (_props: Props) => {
               The Copyright Policy has been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://bsky.social/about/support/copyright"
-                text="bsky.social/about/support/copyright"
+                href={webLinks.copyright}
+                text={webLinks.copyright.replace(/^https?:\/\//, '')}
               />
             </Trans>
           </Text>

--- a/src/view/screens/PrivacyPolicy.tsx
+++ b/src/view/screens/PrivacyPolicy.tsx
@@ -3,6 +3,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
+import {webLinks} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {
   type CommonNavigatorParams,
@@ -30,8 +31,8 @@ export const PrivacyPolicyScreen = (_props: Props) => {
               The Privacy Policy has been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://bsky.social/about/support/privacy-policy"
-                text="bsky.social/about/support/privacy-policy"
+                href={webLinks.privacy}
+                text={webLinks.privacy.replace(/^https?:\/\//, '')}
               />
             </Trans>
           </Text>

--- a/src/view/screens/TermsOfService.tsx
+++ b/src/view/screens/TermsOfService.tsx
@@ -3,6 +3,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
+import {webLinks} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {
   type CommonNavigatorParams,
@@ -29,8 +30,8 @@ export const TermsOfServiceScreen = (_props: Props) => {
             <Trans>The Terms of Service have been moved to</Trans>{' '}
             <TextLink
               style={pal.link}
-              href="https://bsky.social/about/support/tos"
-              text="bsky.social/about/support/tos"
+              href={webLinks.tos}
+              text={webLinks.tos.replace(/^https?:\/\//, '')}
             />
           </Text>
         </View>

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -6,7 +6,7 @@ import {useLingui} from '@lingui/react'
 import {Plural, Trans} from '@lingui/react/macro'
 import {StackActions, useNavigation} from '@react-navigation/native'
 
-import {FEEDBACK_FORM_URL, HELP_DESK_URL} from '#/lib/constants'
+import {FEEDBACK_FORM_URL, HELP_DESK_URL, webLinks} from '#/lib/constants'
 import {type PressableScale} from '#/lib/custom-animations/PressableScale'
 import {useNavigationTabState} from '#/lib/hooks/useNavigationTabState'
 import {getTabState, TabState} from '#/lib/routes/helpers'
@@ -683,12 +683,12 @@ function ExtraLinks() {
       <InlineLinkText
         style={[a.text_md]}
         label={_(msg`Terms of Service`)}
-        to="https://bsky.social/about/support/tos">
+        to={webLinks.tos}>
         <Trans>Terms of Service</Trans>
       </InlineLinkText>
       <InlineLinkText
         style={[a.text_md]}
-        to="https://bsky.social/about/support/privacy-policy"
+        to={webLinks.privacy}
         label={_(msg`Privacy Policy`)}>
         <Trans>Privacy Policy</Trans>
       </InlineLinkText>

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -5,7 +5,7 @@ import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 
-import {FEEDBACK_FORM_URL, HELP_DESK_URL} from '#/lib/constants'
+import {FEEDBACK_FORM_URL, HELP_DESK_URL, webLinks} from '#/lib/constants'
 import {useKawaiiMode} from '#/state/preferences/kawaii'
 import {useSession} from '#/state/session'
 import {DesktopFeeds} from '#/view/shell/desktop/Feeds'
@@ -112,14 +112,14 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
           </>
         )}
         <InlineLinkText
-          to="https://bsky.social/about/support/privacy-policy"
+          to={webLinks.privacy}
           style={[t.atoms.text_contrast_medium]}
           label={_(msg`Privacy`)}>
           {_(msg`Privacy`)}
         </InlineLinkText>
         <Text style={[t.atoms.text_contrast_low]}>{' ∙ '}</Text>
         <InlineLinkText
-          to="https://bsky.social/about/support/tos"
+          to={webLinks.tos}
           style={[t.atoms.text_contrast_medium]}
           label={_(msg`Terms`)}>
           {_(msg`Terms`)}


### PR DESCRIPTION
## Summary

Many user-facing links were hardcoded to `bsky.app` / `bsky.social` / `blueskyweb.zendesk.com`, bypassing the brand config. This routes them through brand config so each brand stays correct, makes **CoSeeker the default brand**, and establishes coseeker.org as the legal-pages fallback (with optional per-brand overrides).

Closes #40, #43, #44, #46, #48.

## Changes

**Brand architecture**
- `DEFAULT_BRAND_ID` → `coseeker`, so unmapped hosts / `localhost` / native builds without `EXPO_PUBLIC_BRAND` resolve to CoSeeker.
- New `brands/shared/links.ts` (`DEFAULT_BRAND_PAGE_LINKS`) pointing at coseeker.org pages + the feedback Google Form. Every brand spreads it; **Bluesky overrides back to bsky.social/Zendesk**; k4m2a/mdparivaar inherit the coseeker.org defaults. Adds `feedbackForm` + `copyright` to the brand `links` type.
- Set real web hosts: `k4m2a.app`, `mdparivaar.com`.

**Issue fixes**
- **#40** — `BSKY_APP_HOST` / `toShareUrl` derive from `brand.webHost`; link recognition + trusted hosts accept both the brand host and `bsky.app`. Also fixes direct builders: Topic, Hashtag, chat invites, starter-pack links, draft quote URLs.
- **#46** — Logged-out footer Terms/Privacy (Drawer + RightNav) use `webLinks`; Help auto-fixes via `HELP_DESK_URL`.
- **#48 / #44** — `FEEDBACK_FORM_URL` reads `brand.links.feedbackForm` (Google Form for CoSeeker), appending Zendesk prefill params only for Zendesk forms.
- **#43** — Signup `Policies` prefers brand legal links when foreign-PDS signup is disabled, so the consent popup no longer opens Bluesky-titled pages.

**Sweep** — AboutSettings, Takendown, BirthDateSettings, PolicyUpdateOverlay, ReportDialog DMCA/support, legacy policy screens, age-assurance support link, Moderation web-app link → brand-aware. Splash footer Business/Blog/Jobs and standalone verification blog buttons gated to the Bluesky brand.

## Out of scope / follow-up
- Functional AppView/infra hosts (`api.bsky.app`, `go.bsky.app`, cardyb, embed/gif/video), deep-link prefixes, and dev/demo files are intentionally unchanged.
- Deferred: "Bluesky" brand-name body copy and Bluesky blog/help links embedded mid-sentence inside `<Trans>` strings (a separate i18n workstream).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (changed files)
- [x] `yarn test` (linking tests)
- [ ] Manual `yarn web` (CoSeeker): share URL host, footer/legal links, feedback form, signup consent popup