### PR TITLE
feat(brand): brand feed as signed-out + default feed, drop video default

### DIFF
--- a/brands/mdparivaar/brand.ts
+++ b/brands/mdparivaar/brand.ts
@@ -103,7 +103,7 @@ const brand: Brand = {
     {
       type: 'feed',
       value:
-        'at://did:plc:ieyfjh6ystyufa3a7pi3jw5q/app.bsky.feed.generator/mdparivaar',
+        'at://did:plc:ieyfjh6ystyufa3a7pi3jw5q/app.bsky.feed.generator/md-parivaar',
       pinned: true,
     },
     {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -143,8 +143,11 @@ export const BSKY_FEED_OWNER_DIDS = [
   'did:plc:q6gjnaw2blty4crticxkmujt',
 ]
 
-export const DISCOVER_FEED_URI =
-  'at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot'
+// The brand's primary feed doubles as its "discover" feed: it backs the
+// signed-out home and drives discover-specific UI (fresh-content polling,
+// composer prompt, etc.). For the Bluesky brand this resolves to whats-hot,
+// so upstream behavior is unchanged.
+export const DISCOVER_FEED_URI = brand.defaultFeeds[0].value
 export const VIDEO_FEED_URI =
   'at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/thevids'
 export const STAGING_VIDEO_FEED_URI =
@@ -156,11 +159,6 @@ export const VIDEO_FEED_URIS = [VIDEO_FEED_URI, STAGING_VIDEO_FEED_URI]
 // `src/brand/boot.ts` and the type assertion below.
 export const DISCOVER_SAVED_FEED = brand.defaultFeeds[0]
 export const TIMELINE_SAVED_FEED = brand.defaultFeeds[1]
-export const VIDEO_SAVED_FEED = {
-  type: 'feed',
-  value: VIDEO_FEED_URI,
-  pinned: true,
-}
 
 export const RECOMMENDED_SAVED_FEEDS: Pick<
   AppBskyActorDefs.SavedFeed,

--- a/src/screens/Onboarding/StepFinished/index.tsx
+++ b/src/screens/Onboarding/StepFinished/index.tsx
@@ -18,7 +18,6 @@ import {
   BSKY_APP_ACCOUNT_DID,
   DISCOVER_SAVED_FEED,
   TIMELINE_SAVED_FEED,
-  VIDEO_SAVED_FEED,
 } from '#/lib/constants'
 import {useRequestNotificationsPermission} from '#/lib/notifications/notifications'
 import {logger} from '#/logger'
@@ -108,7 +107,9 @@ export function StepFinished() {
           // Interests need to get saved first, then we can write the feeds to prefs
           await agent.setInterestsPref({tags: selectedInterests})
 
-          // Default feeds that every user should have pinned when landing in the app
+          // Default feeds that every user should have pinned when landing in
+          // the app: the brand's primary feed and the following timeline. This
+          // matches the brand defaults seeded at account creation.
           const feedsToSave: AppBskyActorDefs.SavedFeed[] = [
             {
               ...DISCOVER_SAVED_FEED,
@@ -116,10 +117,6 @@ export function StepFinished() {
             },
             {
               ...TIMELINE_SAVED_FEED,
-              id: TID.nextStr(),
-            },
-            {
-              ...VIDEO_SAVED_FEED,
               id: TID.nextStr(),
             },
           ]

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -3,7 +3,6 @@ import {ActivityIndicator, StyleSheet} from 'react-native'
 import {withSpring} from 'react-native-reanimated'
 import {useFocusEffect} from '@react-navigation/native'
 
-import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useOTAUpdates} from '#/lib/hooks/useOTAUpdates'
 import {useSetTitle} from '#/lib/hooks/useSetTitle'
@@ -267,7 +266,7 @@ function HomeScreenReady({
           testID="customFeedPage"
           isPageFocused
           isPageAdjacent={false}
-          feed={`feedgen|${PROD_DEFAULT_FEED('whats-hot')}`}
+          feed={pinnedFeedInfos[0].feedDescriptor}
           renderEmptyState={renderCustomFeedEmptyState}
           feedInfo={pinnedFeedInfos[0]}
         />
@@ -330,7 +329,7 @@ function HomeScreenReady({
         testID="customFeedPage"
         isPageFocused
         isPageAdjacent={false}
-        feed={`feedgen|${PROD_DEFAULT_FEED('whats-hot')}`}
+        feed={pinnedFeedInfos[0].feedDescriptor}
         renderEmptyState={renderCustomFeedEmptyState}
         feedInfo={pinnedFeedInfos[0]}
       />


### PR DESCRIPTION
## Summary

Wires each brand's primary feed (`brand.defaultFeeds[0]`) into the signed-out home and as the logged-in default, and stops pinning the dedicated videos feed by default. Every brand now defaults to exactly **two feeds: the brand feed + the following timeline**.

Brand feeds (published at `did:plc:ieyfjh6ystyufa3a7pi3jw5q`):
- CoSeeker → `.../app.bsky.feed.generator/coseeker`
- K4M2A → `.../app.bsky.feed.generator/k4m2a`
- MD Parivaar → `.../app.bsky.feed.generator/md-parivaar`

Closes #15.

## Changes

- **`DISCOVER_FEED_URI` is now brand-aware** (`brand.defaultFeeds[0].value`). This backs the signed-out home (the PWI "discover" stub) and drives discover-specific UI (fresh-content polling, composer prompt). For the **Bluesky brand it still resolves to whats-hot**, so upstream behavior is unchanged.
- **Signed-out home shows the brand feed** — `Home.tsx` signed-out + demo panes use `pinnedFeedInfos[0].feedDescriptor` instead of the hardcoded Bluesky whats-hot feed.
- **No videos feed by default** — onboarding (`StepFinished`) no longer pins `VIDEO_SAVED_FEED`; it seeds only the brand feed + following, matching what account creation already writes. Removed the now-unused `VIDEO_SAVED_FEED` constant.
- **Fixed MD Parivaar feed rkey** — `mdparivaar` → `md-parivaar` to match the published feed generator record (the old rkey 404s).

## Notes
- Issue #42 ("Feeds aren't updating realtime from Lists") is a **separate** concern — it's about list-backed feeds not reflecting newly added members, which is feed-generator/caching behavior rather than this default-feeds wiring. Not addressed here.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (changed files)
- [ ] Manual `yarn web` per brand: signed-out home shows the brand feed; new account / onboarding pins only brand feed + following (no videos tab)