### PR TITLE
fix(brand): collapse multi-line pongo2 comment that broke SSR rendering

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -151,10 +151,7 @@
 <body>
 {%- block body_all %}
   <div id="splash">
-    {# Only the default brand's mark is inlined server-side; other brands
-       show a correctly-colored blank splash until the JS bundle hydrates
-       and paints the brand mark (see src/brand/boot.ts). The brand mark
-       SVGs are too large to inline into every SSR response. #}
+    {# Only the default brand's mark is inlined server-side; other brands show a correctly-colored blank splash until the JS bundle hydrates and paints the brand mark (see src/brand/boot.ts). The brand mark SVGs are too large to inline into every SSR response. #}
     {%- if brand.ID == "bluesky" %}
     <!-- Bluesky SVG -->
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 57"><path fill="#006AFF" d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805ZM50.127 3.805C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745Z"/></svg>


### PR DESCRIPTION
## Summary

Fixes a site-wide outage on all bskyweb-served hosts (coseeker.com, k4m2a.app, mdparivaar.com, and bsky.app) introduced by d5907f6.

Opening any of these domains served no page; instead the browser downloaded a 0-byte file named after the host.

## Root cause

d5907f6 added a brand-aware splash comment to `bskyweb/templates/base.html` as a multi-line `{# ... #}` block. pongo2 v6 only allows **single-line** `{# #}` comments, so `base.html` failed to parse with a lexer error (`Newline not permitted in a single-line comment`).

## Why it surfaced as a 0-byte download

`home.html`, `post.html`, and `error.html` all `{% extends "base.html" %}`. So:

1. Page render fails to parse `base.html` -> render error.
2. Echo's error handler renders `error.html` as a fallback -> also extends `base.html` -> also fails.
3. Double fault: echo emits an empty response with no `Content-Type`, which browsers save as a 0-byte file named after the host.

## Fix

Collapse the comment onto a single line so `base.html` parses again. No behavior change beyond restoring rendering.

## Testing

Parsed and executed `base.html`, `home.html`, and `error.html` through pongo2 with a branded context; all parse and produce non-empty output (previously a parse error).

## Reviewer notes

- Requires rebuilding/redeploying the bskyweb binary, since templates are compiled in via `embed.FS`.
- Follow-up worth considering: making `error.html` standalone (not extending `base.html`) so a future parse error in `base.html` can't also take down the error page.
