### PR TITLE
Hide Feeds tab on logged-out home screen

### DIFF
--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -27,13 +27,15 @@ export function HomeHeader(
     })
   }, [feeds, hasSession])
 
+  const showFeedsLink = hasSession && !hasPinnedCustom
+
   const items = useMemo(() => {
     const pinnedNames = feeds.map(f => f.displayName)
-    if (!hasPinnedCustom) {
+    if (showFeedsLink) {
       return pinnedNames.concat('Feeds ✨')
     }
     return pinnedNames
-  }, [hasPinnedCustom, feeds])
+  }, [showFeedsLink, feeds])
 
   const onPressFeedsLink = useCallback(() => {
     navigation.navigate('Feeds')
@@ -41,28 +43,30 @@ export function HomeHeader(
 
   const onSelect = useCallback(
     (index: number) => {
-      if (!hasPinnedCustom && index === items.length - 1) {
+      if (showFeedsLink && index === items.length - 1) {
         onPressFeedsLink()
       } else if (onSelectProp) {
         onSelectProp(index)
       }
     },
-    [items.length, onPressFeedsLink, onSelectProp, hasPinnedCustom],
+    [items.length, onPressFeedsLink, onSelectProp, showFeedsLink],
   )
 
   return (
     <HomeHeaderLayout tabBarAnchor={props.tabBarAnchor}>
-      <TabBar
-        key={items.join(',')}
-        onPressSelected={props.onPressSelected}
-        selectedPage={props.selectedPage}
-        onSelect={onSelect}
-        testID={props.testID}
-        items={items}
-        dragProgress={props.dragProgress}
-        dragState={props.dragState}
-        transparent
-      />
+      {items.length > 1 && (
+        <TabBar
+          key={items.join(',')}
+          onPressSelected={props.onPressSelected}
+          selectedPage={props.selectedPage}
+          onSelect={onSelect}
+          testID={props.testID}
+          items={items}
+          dragProgress={props.dragProgress}
+          dragState={props.dragState}
+          transparent
+        />
+      )}
     </HomeHeaderLayout>
   )
 }


### PR DESCRIPTION
## Summary
- The logged-out home screen showed a "Discover" / "Feeds ✨" tab bar, but the Feeds tab links to a screen that requires an account, which is confusing before signup.
- `HomeHeader` was appending the "Feeds ✨" tab whenever the user had no pinned custom feeds, which is always true when logged out.
- Now the Feeds tab (and its selection handling) is gated on `hasSession`, and the tab bar itself is not rendered at all when there's only a single tab (e.g. logged-out users just see "Discover" with no tab bar).

Fixes #66

## Test plan
- [x] Verified in local web preview: logged-out home now shows only the Discover feed with no tab bar.
- [x] `pnpm typecheck`