### PR TITLE
fix: auto-follow @coseeker.com during onboarding instead of Bluesky

### DIFF
--- a/brands/coseeker/brand.ts
+++ b/brands/coseeker/brand.ts
@@ -219,7 +219,7 @@ const brand: Brand = {
     appviewDid: 'did:web:api.bsky.app',
   },
 
-  appAccountDid: 'did:plc:z72i7hdynmk6r22z27h6tvur',
+  appAccountDid: 'did:plc:ieyfjh6ystyufa3a7pi3jw5q', // @coseeker.com
 
   defaultFeeds: [
     {

--- a/brands/k4m2a/brand.ts
+++ b/brands/k4m2a/brand.ts
@@ -272,7 +272,7 @@ const brand: Brand = {
     appviewDid: 'did:web:api.bsky.app',
   },
 
-  appAccountDid: 'did:plc:z72i7hdynmk6r22z27h6tvur',
+  appAccountDid: 'did:plc:ieyfjh6ystyufa3a7pi3jw5q', // @coseeker.com
 
   defaultFeeds: [
     {

--- a/brands/mdparivaar/brand.ts
+++ b/brands/mdparivaar/brand.ts
@@ -101,7 +101,7 @@ const brand: Brand = {
     appviewDid: 'did:web:api.bsky.app',
   },
 
-  appAccountDid: 'did:plc:z72i7hdynmk6r22z27h6tvur',
+  appAccountDid: 'did:plc:ieyfjh6ystyufa3a7pi3jw5q', // @coseeker.com
 
   defaultFeeds: [
     {


### PR DESCRIPTION
## Summary
- Onboarding auto-follows a hardcoded account via `BSKY_APP_ACCOUNT_DID` (`src/screens/Onboarding/StepFinished/index.tsx`), sourced from each brand's `appAccountDid`.
- `coseeker`, `k4m2a`, and `mdparivaar` brand configs still had the real Bluesky team DID (`did:plc:z72i7hdynmk6r22z27h6tvur`), copy-pasted from upstream.
- Updated all three to `@coseeker.com`'s DID (`did:plc:ieyfjh6ystyufa3a7pi3jw5q`) so new users follow the right account on signup.
- `brands/bluesky/brand.ts` is intentionally left unchanged — its docblock states it's meant to be an exact clone of upstream Bluesky behavior (used as the fallback when no brand override is set).

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Manually verify by completing onboarding on a coseeker build and confirming the new account follows @coseeker.com

Fixes #61