### PR TITLE
Use brand-aware wordmark on age assurance no-access screen

### DIFF
--- a/src/ageAssurance/components/NoAccessScreen.tsx
+++ b/src/ageAssurance/components/NoAccessScreen.tsx
@@ -12,6 +12,7 @@ import {
 import {dateDiff, useGetTimeAgo} from '#/lib/hooks/useTimeAgo'
 import {useIsBirthdateUpdateAllowed} from '#/state/birthdate'
 import {useSessionApi} from '#/state/session'
+import {Logotype} from '#/view/icons/Logotype'
 import {DeactivateAccountDialog} from '#/screens/Settings/components/DeactivateAccountDialog'
 import {DeleteAccountDialog} from '#/screens/Settings/components/DeleteAccountDialog'
 import {atoms as a, useBreakpoints, useTheme, web} from '#/alf'
@@ -24,7 +25,6 @@ import * as Dialog from '#/components/Dialog'
 import {useDialogControl} from '#/components/Dialog'
 import {BirthDateSettingsDialog} from '#/components/dialogs/BirthDateSettings'
 import {DeviceLocationRequestDialog} from '#/components/dialogs/DeviceLocationRequestDialog'
-import {Full as Logo} from '#/components/icons/Logo'
 import {ShieldCheck_Stroke2_Corner0_Rounded as ShieldIcon} from '#/components/icons/Shield'
 import {createStaticClick, SimpleInlineLinkText} from '#/components/Link'
 import {Outlet as PortalOutlet} from '#/components/Portal'
@@ -240,7 +240,7 @@ export function NoAccessScreen() {
             )}
 
             <View style={[a.pt_lg, a.gap_xl, {maxWidth: 280}]}>
-              <Logo width={120} textFill={t.atoms.text.color} />
+              <Logotype width={120} fill={t.atoms.text.color} />
               <Text
                 style={[
                   a.text_sm,


### PR DESCRIPTION
## Summary

Replace the hardcoded Bluesky logo on the age assurance no-access screen with the brand-aware wordmark so non-Bluesky brands (e.g. CoSeeker) no longer show Bluesky branding.

## Why this is needed

The age assurance no-access screen (`src/ageAssurance/components/NoAccessScreen.tsx`) rendered the hardcoded Bluesky `Full` logo (butterfly mark + "Bluesky" wordmark). Under the CoSeeker brand this still displayed "Bluesky" branding at the bottom of the screen, as reported in the issue.

## Type of change

- [x] Branding/copy update

## Related issue

Closes #62

## What changed

- Swapped the hardcoded `Full` Bluesky logo for the brand-aware `Logotype`, which renders the active brand's wordmark from the brand registry (e.g. "CoSeeker").
- Moved the import into the correct `#/view` group to satisfy the `simple-import-sort` ESLint rule.

## Testing

- [x] I checked the affected screen or flow
- [x] I checked that no unrelated behavior changed

## Contributor checklist

- [x] My change is small and focused
- [x] I have explained what changed and why
- [x] I have avoided unrelated formatting or refactoring
- [x] My contribution supports CoSeeker / K4M2A's mission and product principles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FPgz5iEhxiC2XbAoG2KL1