### PR TITLE
Skip onboarding flow after signup

### DIFF
--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -337,7 +337,7 @@ export function useSubmitSignup() {
          * Must happen last so that if the user has multiple tabs open and
          * createAccount fails, one tab is not stuck in onboarding — Eric
          */
-        onboardingDispatch({type: 'start'})
+        onboardingDispatch({type: 'finish'})
       } catch (err) {
         const e = err as Error
         let errMsg = e.toString()

--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -40,10 +40,11 @@ export function SignupQueued() {
     try {
       const res = await agent.com.atproto.temp.checkSignupQueue()
       if (res.data.activated) {
-        // ready to go, exchange the access token for a usable one and kick off onboarding
+        // ready to go, exchange the access token for a usable one
         await agent.sessionManager.refreshSession()
         if (!isSignupQueued(agent.session?.accessJwt)) {
-          onboardingDispatch({type: 'start'})
+          // onboarding is skipped entirely, so mark it complete right away
+          onboardingDispatch({type: 'finish'})
         }
       } else {
         // not ready, update UI


### PR DESCRIPTION
## Summary
- Closes #67
- Users now go straight from sign-in/account creation into the app instead of through the multi-step onboarding screens (avatar, interests, suggested accounts/starter packs, contacts).
- Username/handle selection already happens as part of the account-creation form itself, so that's unaffected — this only skips the screens that come *after* signup.
- Implemented by dispatching `{type: 'finish'}` instead of `{type: 'start'}` on the onboarding state machine right after account creation succeeds ([src/screens/Signup/state.ts](src/screens/Signup/state.ts)) and after a queued signup activates ([src/screens/SignupQueued.tsx](src/screens/SignupQueued.tsx)). The top-level router only renders `<Onboarding />` when `onboardingState.isActive`, which is `false` once the step is marked `'Home'`.
- Left the dev-only "Reset onboarding" debug toggle and the e2e test control untouched since they're testing conveniences, not part of the real user flow.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `eslint` passes on changed files
- [ ] Manually verify a fresh signup on device/web goes straight to the Home feed with no onboarding screens