### PR TITLE
Force-disable onboarding regardless of persisted state

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -211,6 +211,19 @@ export async function createAgentAndCreateAccount(
         logger.info(`createAgentAndCreateAccount: failed to set initial feeds`)
         throw e
       }),
+      /*
+       * Auto-follow the brand account. This used to happen at the end of
+       * onboarding (StepFinished), which is now skipped entirely, so it
+       * happens here as part of account setup instead.
+       */
+      networkRetry(3, () => {
+        return agent.follow(getActiveBrand().appAccountDid)
+      }).catch(e => {
+        logger.info(
+          `createAgentAndCreateAccount: failed to follow brand account`,
+        )
+        throw e
+      }),
       // wait for AA data to load first, then check state
       aa.then(() => {
         const {flags} = unsafeGetAndComputeAgeAssurance({did: account.did})

--- a/src/state/shell/onboarding.tsx
+++ b/src/state/shell/onboarding.tsx
@@ -114,9 +114,15 @@ export function isOnboardingActive() {
 }
 
 function compute(state: persisted.Schema['onboarding']): StateContext {
+  /*
+   * Onboarding is disabled entirely (issue #67) - users go straight into
+   * the app after signup. The persisted step is deliberately ignored so
+   * stale state written by older builds (or any stray 'start' dispatch)
+   * can never re-trigger the onboarding screens.
+   */
   return {
     ...state,
-    isActive: state.step !== 'Home',
-    isComplete: state.step === 'Home',
+    isActive: false,
+    isComplete: true,
   }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #75 / closes #67 for real this time.
- #75 only stopped *new* signups from dispatching the onboarding `start` action, but whether onboarding renders is computed from a **persisted** `step` value. Any device or browser that already had a step like `Welcome` persisted (from a signup done on an older build, or an interrupted onboarding) would still show the onboarding screens.
- This hardens the fix at the single gate: `compute()` in [src/state/shell/onboarding.tsx](src/state/shell/onboarding.tsx) now always returns `isActive: false` / `isComplete: true`, ignoring the persisted step. The onboarding screens can never render, regardless of stale state or any stray `start` dispatch (e.g. the hidden dev-settings toggle).
- **Preserves the brand-account auto-follow**: the follow of `appAccountDid` (@coseeker.com) used to happen in onboarding's `StepFinished`, which no longer runs. It now happens in `createAgentAndCreateAccount` ([src/state/session/agent.ts](src/state/session/agent.ts)) alongside the default feed seeding, fire-and-forget with retries.

## Notes on other things StepFinished used to do
- Default feed pinning: already seeded at account creation in `agent.ts` – unaffected.
- Interests prefs + avatar upload: intentionally gone along with their onboarding steps.
- Starter-pack auto-follows and `joinedViaStarterPack`: no longer applied at signup (only relevant if signup came from a starter-pack link).

## Test plan
- [x] `pnpm typecheck` passes
- [x] `eslint` passes on changed files
- [ ] On a device that was previously stuck showing onboarding, reload the app – it should go straight to the Home feed
- [ ] Sign up a fresh account and confirm it follows @coseeker.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)