### PR TITLE
Await default feed seeding and brand follow at signup

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -175,7 +175,47 @@ export async function createAgentAndCreateAccount(
   // do this last
   const aa = prefetchAgeAssuranceServerData({agent})
 
-  // Not awaited so that we can still get into onboarding.
+  /*
+   * With onboarding skipped, the Home screen renders as soon as account
+   * creation resolves, and its preferences fetch calls getPreferences. If
+   * that runs before any savedFeeds pref exists on the server, @atproto/api
+   * writes back a following-only default, clobbering the brand defaults.
+   * So the feed seeding (and the brand follow, so the following feed is not
+   * empty on first render) must complete before we return. Failures are
+   * logged but do not block signup.
+   */
+  if (IS_PROD_SERVICE(service)) {
+    await Promise.allSettled([
+      networkRetry(2, () => {
+        return agent.overwriteSavedFeeds(
+          getActiveBrand().defaultFeeds.map(feed => ({
+            ...feed,
+            id: TID.nextStr(),
+          })),
+        )
+      }).catch(e => {
+        logger.error(
+          `createAgentAndCreateAccount: failed to set initial feeds`,
+          {safeMessage: e},
+        )
+      }),
+      /*
+       * Auto-follow the brand account. This used to happen at the end of
+       * onboarding (StepFinished), which is now skipped entirely, so it
+       * happens here as part of account setup instead.
+       */
+      networkRetry(2, () => {
+        return agent.follow(getActiveBrand().appAccountDid)
+      }).catch(e => {
+        logger.error(
+          `createAgentAndCreateAccount: failed to follow brand account`,
+          {safeMessage: e},
+        )
+      }),
+    ])
+  }
+
+  // Not awaited so that we can still get into the app quickly.
   // This is OK because we won't let you toggle adult stuff until you set the date.
   if (IS_PROD_SERVICE(service)) {
     void Promise.allSettled([
@@ -197,30 +237,6 @@ export async function createAgentAndCreateAccount(
       }).catch(e => {
         logger.info(
           `createAgentAndCreateAccount: failed to set initial profile`,
-        )
-        throw e
-      }),
-      networkRetry(1, () => {
-        return agent.overwriteSavedFeeds(
-          getActiveBrand().defaultFeeds.map(feed => ({
-            ...feed,
-            id: TID.nextStr(),
-          })),
-        )
-      }).catch(e => {
-        logger.info(`createAgentAndCreateAccount: failed to set initial feeds`)
-        throw e
-      }),
-      /*
-       * Auto-follow the brand account. This used to happen at the end of
-       * onboarding (StepFinished), which is now skipped entirely, so it
-       * happens here as part of account setup instead.
-       */
-      networkRetry(3, () => {
-        return agent.follow(getActiveBrand().appAccountDid)
-      }).catch(e => {
-        logger.info(
-          `createAgentAndCreateAccount: failed to follow brand account`,
         )
         throw e
       }),


### PR DESCRIPTION
## Summary
Follow-up to #76. New signups were landing on Home with only the Following feed pinned – the brand default feed was missing.

**Root cause:** with onboarding skipped, Home renders as soon as account creation resolves and immediately fetches preferences. `getPreferences()` in `@atproto/api` has a migration path: when no `savedFeeds` pref exists on the account yet, it synthesizes a following-only default and **writes it back to the server**. Our brand-feed seeding in `createAgentAndCreateAccount` was fire-and-forget (the old comment: "Not awaited so that we can still get into onboarding"), so the two writes raced. Previously onboarding sat in between and `StepFinished` re-wrote the feeds last, masking the race. Now, when the preferences fetch won, the following-only default permanently clobbered the brand defaults.

**Fix:** in [src/state/session/agent.ts](src/state/session/agent.ts), await the default feed seeding and the brand-account follow (so the following feed isn't empty on first render) before account creation returns. The rest of the post-signup setup (birth date, initial profile, age-assurance chat restrictions) stays fire-and-forget. Seeding failures are logged but don't block signup. The query cache is per-account (`QueryProvider` keyed by DID), so the first preferences fetch after signup is guaranteed to see the seeded feeds.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `eslint` passes on the changed file
- [ ] Fresh signup on coseeker.org lands on Home with the CoSeeker feed + Following pinned, and follows @coseeker.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)