### PR TITLE
Collect name at signup, restore profile-picture-only onboarding

### DIFF
--- a/__e2e__/flows/create-account.yml
+++ b/__e2e__/flows/create-account.yml
@@ -38,9 +38,14 @@ appId: xyz.blueskyweb.app
     point: 20%,20%
     repeat: 2
     delay: 1000
+# enter the handle first: typing the name first would auto-suggest a handle
+# and inputText would append to it
 - tapOn:
     id: "handleInput"
 - inputText: "e2e-test"
+- tapOn:
+    id: "displayNameInput"
+- inputText: "E2E Test"
 - extendedWaitUntil:
     visible:
       id: "handleAvailableCheck"

--- a/__e2e__/flows/onboarding.yml
+++ b/__e2e__/flows/onboarding.yml
@@ -23,21 +23,9 @@ appId: xyz.blueskyweb.app
 - waitForAnimationToEnd
 - tapOn: "Done"
 - waitForAnimationToEnd
+# onboarding is a single step: continuing saves and lands on Home
 - tapOn:
     id: "onboardingContinue"
-- assertVisible: "What are your interests?"
-- tapOn:
-    id: "onboardingContinue"
-- assertVisible: "Suggested for you"
-# mock server doesn't have suggestions api
-- tapOn: "Skip to next step"
-- swipe:
-    direction: "LEFT"
-- swipe:
-    direction: "LEFT"
-- assertVisible: "Complete onboarding and start using your account"
-- tapOn:
-    id: "onboardingFinish"
 - tapOn:
     label: "NUX, if applicable"
     text: "Close"

--- a/src/screens/Onboarding/Layout.tsx
+++ b/src/screens/Onboarding/Layout.tsx
@@ -223,6 +223,11 @@ export function OnboardingPosition() {
   const {state} = useOnboardingInternalState()
   const t = useTheme()
 
+  // a single-step flow needs no "Step 1 of 1" indicator
+  if (state.totalSteps <= 1) {
+    return null
+  }
+
   return (
     <Text style={[a.text_sm, a.font_medium, t.atoms.text_contrast_medium]}>
       <Trans>

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -41,11 +41,13 @@ import {
   PlaceholderCanvas,
   type PlaceholderCanvasRef,
 } from '#/screens/Onboarding/StepProfile/PlaceholderCanvas'
+import {useFinishOnboarding} from '#/screens/Onboarding/useFinishOnboarding'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
-import {Button, ButtonText} from '#/components/Button'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {useSheetWrapper} from '#/components/Dialog/sheet-wrapper'
 import {CircleInfo_Stroke2_Corner0_Rounded} from '#/components/icons/CircleInfo'
+import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 import {IS_NATIVE, IS_WEB} from '#/env'
@@ -88,6 +90,7 @@ export function StepProfile() {
   const [error, setError] = useState('')
 
   const {state, dispatch} = useOnboardingInternalState()
+  const {finishOnboarding, saving} = useFinishOnboarding()
   const [avatar, setAvatar] = useState<Avatar>({
     image: state.profileStepResults?.image,
     placeholder: state.profileStepResults.creatorState?.emoji || emojiItems.at,
@@ -158,9 +161,14 @@ export function StepProfile() {
       imageUri = await canvasRef.current?.capture()
     }
 
+    /*
+     * The results are passed to finishOnboarding directly (rather than read
+     * from context) because the dispatch above won't have flushed yet. The
+     * dispatch still runs to keep context state consistent.
+     */
+    let results = state.profileStepResults
     if (imageUri) {
-      dispatch({
-        type: 'setProfileStepResults',
+      results = {
         image: avatar.image,
         imageUri,
         imageMime: avatar.image?.mime ?? 'image/jpeg',
@@ -169,12 +177,22 @@ export function StepProfile() {
           emoji: avatar.placeholder,
           backgroundColor: avatar.backgroundColor,
         },
+      }
+      dispatch({
+        type: 'setProfileStepResults',
+        image: results.image,
+        imageUri: results.imageUri,
+        imageMime: results.imageMime ?? 'image/jpeg',
+        isCreatedAvatar: results.isCreatedAvatar,
+        creatorState: results.creatorState,
       })
     }
 
-    dispatch({type: 'next'})
     ax.metric('onboarding:profile:nextPressed', {})
-  }, [ax, avatar, dispatch])
+
+    // This is the only onboarding step, so continuing finishes onboarding.
+    await finishOnboarding(results)
+  }, [ax, avatar, dispatch, state.profileStepResults, finishOnboarding])
 
   const onDoneCreating = useCallback(() => {
     setAvatar(prev => ({
@@ -297,17 +315,20 @@ export function StepProfile() {
               testID="onboardingContinue"
               color="primary"
               size="large"
-              label={_(msg`Continue to next step`)}
+              label={_(msg`Finish and start using your account`)}
+              disabled={saving}
               onPress={onContinue}>
               <ButtonText>
                 <Trans>Continue</Trans>
               </ButtonText>
+              {saving && <ButtonIcon icon={Loader} />}
             </Button>
             <Button
               testID="onboardingAvatarCreator"
               color="primary_subtle"
               size="large"
               label={_(msg`Open avatar creator`)}
+              disabled={saving}
               onPress={onSecondaryPress}>
               <ButtonText>
                 {avatar.useCreatedAvatar ? (

--- a/src/screens/Onboarding/index.tsx
+++ b/src/screens/Onboarding/index.tsx
@@ -1,8 +1,6 @@
 import {useMemo, useReducer} from 'react'
 import {View} from 'react-native'
-import * as bcp47Match from 'bcp-47-match'
 
-import {useLanguagePrefs} from '#/state/preferences'
 import {
   Layout,
   OnboardingControls,
@@ -13,51 +11,26 @@ import {
   createInitialOnboardingState,
   reducer,
 } from '#/screens/Onboarding/state'
-import {StepFinished} from '#/screens/Onboarding/StepFinished'
-import {StepInterests} from '#/screens/Onboarding/StepInterests'
 import {StepProfile} from '#/screens/Onboarding/StepProfile'
 import {atoms as a, useTheme} from '#/alf'
-import {useIsFindContactsFeatureEnabledBasedOnGeolocation} from '#/components/contacts/country-allowlist'
-import {useFindContactsFlowState} from '#/components/contacts/state'
 import {Portal} from '#/components/Portal'
 import {ScreenTransition} from '#/components/ScreenTransition'
-import {useAnalytics} from '#/analytics'
-import {ENV, IS_NATIVE} from '#/env'
-import {StepFindContacts} from './StepFindContacts'
-import {StepFindContactsIntro} from './StepFindContactsIntro'
-import {StepSuggestedAccounts} from './StepSuggestedAccounts'
-import {StepSuggestedStarterpacks} from './StepSuggestedStarterpacks'
 
+/*
+ * Onboarding is a single step: the profile picture. The finishing side
+ * effects (avatar upload etc.) run from StepProfile's continue button via
+ * useFinishOnboarding. Display name and username are collected during
+ * signup, and default feeds plus the brand-account follow are seeded at
+ * account creation.
+ */
 export function Onboarding() {
   const t = useTheme()
-  const ax = useAnalytics()
-
-  const {contentLanguages} = useLanguagePrefs()
-  const probablySpeaksEnglish = useMemo(() => {
-    if (contentLanguages.length === 0) return true
-    return bcp47Match.basicFilter('en', contentLanguages).length > 0
-  }, [contentLanguages])
-
-  // starter packs screen is currently geared towards english-speaking accounts
-  const showSuggestedStarterpacks = ENV !== 'e2e' && probablySpeaksEnglish
-
-  const findContactsEnabled =
-    useIsFindContactsFeatureEnabledBasedOnGeolocation()
-  const showFindContacts =
-    ENV !== 'e2e' &&
-    IS_NATIVE &&
-    findContactsEnabled &&
-    !ax.features.enabled(ax.features.ImportContactsOnboardingDisable)
 
   const [state, dispatch] = useReducer(
     reducer,
-    {
-      starterPacksStepEnabled: showSuggestedStarterpacks,
-      findContactsStepEnabled: showFindContacts,
-    },
+    undefined,
     createInitialOnboardingState,
   )
-  const [contactsFlowState, contactsFlowDispatch] = useFindContactsFlowState()
 
   return (
     <Portal>
@@ -70,28 +43,9 @@ export function Onboarding() {
                 key={state.activeStep}
                 direction={state.stepTransitionDirection}
                 style={a.flex_1}>
-                {/* FindContactsFlow cannot be nested in Layout */}
-                {state.activeStep === 'find-contacts' ? (
-                  <StepFindContacts
-                    flowState={contactsFlowState}
-                    flowDispatch={contactsFlowDispatch}
-                  />
-                ) : (
-                  <Layout>
-                    {state.activeStep === 'profile' && <StepProfile />}
-                    {state.activeStep === 'interests' && <StepInterests />}
-                    {state.activeStep === 'suggested-accounts' && (
-                      <StepSuggestedAccounts />
-                    )}
-                    {state.activeStep === 'suggested-starterpacks' && (
-                      <StepSuggestedStarterpacks />
-                    )}
-                    {state.activeStep === 'find-contacts-intro' && (
-                      <StepFindContactsIntro />
-                    )}
-                    {state.activeStep === 'finished' && <StepFinished />}
-                  </Layout>
-                )}
+                <Layout>
+                  {state.activeStep === 'profile' && <StepProfile />}
+                </Layout>
               </ScreenTransition>
             </Context.Provider>
           </OnboardingHeaderSlot.Provider>

--- a/src/screens/Onboarding/state.ts
+++ b/src/screens/Onboarding/state.ts
@@ -72,23 +72,20 @@ export type OnboardingAction =
         | undefined
     }
 
-export function createInitialOnboardingState(
-  {
-    starterPacksStepEnabled,
-    findContactsStepEnabled,
-  }: {
-    starterPacksStepEnabled: boolean
-    findContactsStepEnabled: boolean
-  } = {starterPacksStepEnabled: true, findContactsStepEnabled: false},
-): OnboardingState {
+export function createInitialOnboardingState(): OnboardingState {
+  /*
+   * Onboarding is trimmed to just the profile-picture step. The other steps
+   * (and their components) still exist but are disabled. The finishing side
+   * effects run from StepProfile's continue button via useFinishOnboarding.
+   */
   const screens: OnboardingState['screens'] = {
     profile: true,
-    interests: true,
-    'suggested-accounts': true,
-    'suggested-starterpacks': starterPacksStepEnabled,
-    'find-contacts-intro': findContactsStepEnabled,
-    'find-contacts': findContactsStepEnabled,
-    finished: true,
+    interests: false,
+    'suggested-accounts': false,
+    'suggested-starterpacks': false,
+    'find-contacts-intro': false,
+    'find-contacts': false,
+    finished: false,
   }
 
   return {
@@ -148,10 +145,7 @@ export function reducer(
       break
     }
     case 'finish': {
-      next = createInitialOnboardingState({
-        starterPacksStepEnabled: s.screens['suggested-starterpacks'],
-        findContactsStepEnabled: s.screens['find-contacts'],
-      })
+      next = createInitialOnboardingState()
       break
     }
     case 'setInterestsStepResults': {

--- a/src/screens/Onboarding/useFinishOnboarding.ts
+++ b/src/screens/Onboarding/useFinishOnboarding.ts
@@ -1,0 +1,222 @@
+import {useState} from 'react'
+import {
+  type AppBskyActorDefs,
+  type AppBskyActorProfile,
+  type AppBskyGraphDefs,
+  AppBskyGraphStarterpack,
+  type Un$Typed,
+} from '@atproto/api'
+import {TID} from '@atproto/common-web'
+import {useQueryClient} from '@tanstack/react-query'
+
+import {uploadBlob} from '#/lib/api'
+import {DISCOVER_SAVED_FEED, TIMELINE_SAVED_FEED} from '#/lib/constants'
+import {logger} from '#/logger'
+import {useSetHasCheckedForStarterPack} from '#/state/preferences/used-starter-packs'
+import {getAllListMembers} from '#/state/queries/list-members'
+import {preferencesQueryKey} from '#/state/queries/preferences'
+import {RQKEY as profileRQKey} from '#/state/queries/profile'
+import {useAgent} from '#/state/session'
+import {useOnboardingDispatch} from '#/state/shell'
+import {
+  useActiveStarterPack,
+  useSetActiveStarterPack,
+} from '#/state/shell/landing'
+import {useProgressGuideControls} from '#/state/shell/progress-guide'
+import {
+  type OnboardingState,
+  useOnboardingInternalState,
+} from '#/screens/Onboarding/state'
+import {bulkWriteFollows} from '#/screens/Onboarding/util'
+import {useAnalytics} from '#/analytics'
+import * as bsky from '#/types/bsky'
+
+/**
+ * Runs the side effects that complete onboarding: uploads the avatar and
+ * saves it to the profile, applies starter-pack follows and feeds when the
+ * user signed up via a starter pack, and marks onboarding finished.
+ *
+ * Extracted from the old StepFinished screen, which no longer renders. Note
+ * that the brand-account follow and default feed seeding happen at account
+ * creation (see createAgentAndCreateAccount), not here.
+ *
+ * `finishOnboarding` takes the profile step results as an argument rather
+ * than reading them from context, because the caller dispatches them in the
+ * same tick.
+ */
+export function useFinishOnboarding() {
+  const ax = useAnalytics()
+  const {dispatch} = useOnboardingInternalState()
+  const onboardDispatch = useOnboardingDispatch()
+  const [saving, setSaving] = useState(false)
+  const queryClient = useQueryClient()
+  const agent = useAgent()
+  const activeStarterPack = useActiveStarterPack()
+  const setActiveStarterPack = useSetActiveStarterPack()
+  const setHasCheckedForStarterPack = useSetHasCheckedForStarterPack()
+  const {startProgressGuide} = useProgressGuideControls()
+
+  const finishOnboarding = async (
+    profileStepResults: OnboardingState['profileStepResults'],
+  ) => {
+    setSaving(true)
+
+    let starterPack: AppBskyGraphDefs.StarterPackView | undefined
+    let listItems: AppBskyGraphDefs.ListItemView[] | undefined
+
+    if (activeStarterPack?.uri) {
+      try {
+        const spRes = await agent.app.bsky.graph.getStarterPack({
+          starterPack: activeStarterPack.uri,
+        })
+        starterPack = spRes.data.starterPack
+      } catch (e) {
+        logger.error('Failed to fetch starter pack', {safeMessage: e})
+        // don't tell the user, just get them through onboarding.
+      }
+      try {
+        if (starterPack?.list) {
+          listItems = await getAllListMembers(agent, starterPack.list.uri)
+        }
+      } catch (e) {
+        logger.error('Failed to fetch starter pack list items', {
+          safeMessage: e,
+        })
+        // don't tell the user, just get them through onboarding.
+      }
+    }
+
+    try {
+      await Promise.all([
+        (async () => {
+          /*
+           * The brand account is already followed at account creation, so
+           * follows here are only needed for starter-pack members.
+           */
+          if (starterPack && listItems?.length) {
+            await bulkWriteFollows(
+              agent,
+              listItems.map(i => i.subject.did),
+              {uri: starterPack.uri, cid: starterPack.cid},
+            )
+          }
+        })(),
+        (async () => {
+          /*
+           * Default feeds are seeded at account creation; only rewrite them
+           * when starter-pack feeds need to be appended.
+           */
+          if (starterPack && starterPack.feeds?.length) {
+            const feedsToSave: AppBskyActorDefs.SavedFeed[] = [
+              {
+                ...DISCOVER_SAVED_FEED,
+                id: TID.nextStr(),
+              },
+              {
+                ...TIMELINE_SAVED_FEED,
+                id: TID.nextStr(),
+              },
+              ...starterPack.feeds.map(f => ({
+                type: 'feed',
+                value: f.uri,
+                pinned: true,
+                id: TID.nextStr(),
+              })),
+            ]
+            await agent.overwriteSavedFeeds(feedsToSave)
+          }
+        })(),
+        (async () => {
+          const {imageUri, imageMime} = profileStepResults
+          const blobPromise =
+            imageUri && imageMime
+              ? uploadBlob(agent, imageUri, imageMime)
+              : undefined
+
+          await agent.upsertProfile(async existing => {
+            /*
+             * displayName is deliberately not touched here - it is set at
+             * account creation from the name entered during signup.
+             */
+            const next: Un$Typed<AppBskyActorProfile.Record> = existing ?? {}
+
+            if (blobPromise) {
+              const res = await blobPromise
+              if (res.data.blob) {
+                next.avatar = res.data.blob
+              }
+            }
+
+            if (starterPack) {
+              next.joinedViaStarterPack = {
+                uri: starterPack.uri,
+                cid: starterPack.cid,
+              }
+            }
+
+            if (!next.createdAt) {
+              next.createdAt = new Date().toISOString()
+            }
+            return next
+          })
+
+          ax.metric('onboarding:finished:avatarResult', {
+            avatarResult: profileStepResults.isCreatedAvatar
+              ? 'created'
+              : profileStepResults.image
+                ? 'uploaded'
+                : 'default',
+          })
+        })(),
+      ])
+    } catch (e) {
+      logger.info(`onboarding: bulk save failed`)
+      logger.error(e instanceof Error ? e : String(e))
+      // don't alert the user, just let them into their account
+    }
+
+    // Try to ensure that prefs and profile are up-to-date by the time we render Home.
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: preferencesQueryKey,
+      }),
+      queryClient.invalidateQueries({
+        queryKey: profileRQKey(agent.session?.did ?? ''),
+      }),
+    ]).catch(e => {
+      logger.error(e)
+      // Keep going.
+    })
+
+    setSaving(false)
+    setActiveStarterPack(undefined)
+    setHasCheckedForStarterPack(true)
+    startProgressGuide('follow-10')
+    dispatch({type: 'finish'})
+    onboardDispatch({type: 'finish'})
+    ax.metric('onboarding:finished:nextPressed', {
+      usedStarterPack: Boolean(starterPack),
+      starterPackName:
+        starterPack &&
+        bsky.dangerousIsType<AppBskyGraphStarterpack.Record>(
+          starterPack.record,
+          AppBskyGraphStarterpack.isRecord,
+        )
+          ? starterPack.record.name
+          : undefined,
+      starterPackCreator: starterPack?.creator.did,
+      starterPackUri: starterPack?.uri,
+      profilesFollowed: listItems?.length ?? 0,
+      feedsPinned: starterPack?.feeds?.length ?? 0,
+    })
+    if (starterPack && listItems?.length) {
+      ax.metric('starterPack:followAll', {
+        logContext: 'Onboarding',
+        starterPack: starterPack.uri,
+        count: listItems?.length,
+      })
+    }
+  }
+
+  return {finishOnboarding, saving}
+}

--- a/src/screens/Signup/StepHandle/index.tsx
+++ b/src/screens/Signup/StepHandle/index.tsx
@@ -12,6 +12,7 @@ import {Plural, Trans} from '@lingui/react/macro'
 
 import {
   createFullHandle,
+  makeValidHandle,
   MAX_SERVICE_HANDLE_LENGTH,
   validateServiceHandle,
 } from '#/lib/strings/handles'
@@ -37,6 +38,13 @@ export function StepHandle() {
   const t = useTheme()
   const {state, dispatch} = useSignupContext()
   const [draftValue, setDraftValue] = useState(state.handle)
+  const [nameDraft, setNameDraft] = useState(state.displayName)
+  /*
+   * Once the user edits the handle themselves (or picks a suggestion), stop
+   * auto-filling it from the name. Initialized true when returning to this
+   * step with a handle already chosen.
+   */
+  const [handleTouched, setHandleTouched] = useState(state.handle !== '')
   const isNextLoading = useThrottledValue(state.isLoading, 500)
 
   const validCheck = validateServiceHandle(draftValue, state.userDomain)
@@ -59,6 +67,10 @@ export function StepHandle() {
     dispatch({
       type: 'setHandle',
       value: handle,
+    })
+    dispatch({
+      type: 'setDisplayName',
+      value: nameDraft.trim(),
     })
 
     if (!validCheck.overall) {
@@ -116,6 +128,10 @@ export function StepHandle() {
       type: 'setHandle',
       value: handle,
     })
+    dispatch({
+      type: 'setDisplayName',
+      value: nameDraft.trim(),
+    })
     dispatch({type: 'prev'})
     ax.metric('signup:backPressed', {activeStep: state.activeStep})
   }
@@ -128,7 +144,9 @@ export function StepHandle() {
     !isHandleAvailable.available
   const isNotReady = isPending || !hasDebounceSettled
   const isNextDisabled =
-    !validCheck.overall || !!state.error || isNotReady ? true : isHandleTaken
+    !nameDraft.trim() || !validCheck.overall || !!state.error || isNotReady
+      ? true
+      : isHandleTaken
 
   const textFieldInvalid =
     isHandleTaken ||
@@ -141,6 +159,37 @@ export function StepHandle() {
     <>
       <View style={[a.gap_sm, a.pt_lg, a.z_10]}>
         <View>
+          <TextField.LabelText>
+            <Trans>Name</Trans>
+          </TextField.LabelText>
+          <TextField.Root
+            isInvalid={!!state.error && state.errorField === 'display-name'}>
+            <TextField.Input
+              testID="displayNameInput"
+              onChangeText={val => {
+                if (state.error) {
+                  dispatch({type: 'setError', value: ''})
+                }
+                setNameDraft(val)
+                if (!handleTouched) {
+                  setDraftValue(
+                    makeValidHandle(val).slice(0, MAX_SERVICE_HANDLE_LENGTH),
+                  )
+                }
+              }}
+              label={_(msg`Your name`)}
+              defaultValue={nameDraft}
+              autoCapitalize="words"
+              autoComplete="name"
+              autoCorrect={false}
+              autoFocus
+            />
+          </TextField.Root>
+        </View>
+        <View>
+          <TextField.LabelText>
+            <Trans>Username</Trans>
+          </TextField.LabelText>
           <TextField.Root isInvalid={textFieldInvalid}>
             <TextField.Icon icon={AtIcon} />
             <TextField.Input
@@ -149,6 +198,7 @@ export function StepHandle() {
                 if (state.error) {
                   dispatch({type: 'setError', value: ''})
                 }
+                setHandleTouched(true)
                 setDraftValue(val.toLocaleLowerCase())
               }}
               label={state.userDomain}
@@ -156,7 +206,6 @@ export function StepHandle() {
               keyboardType="ascii-capable" // fix for iOS replacing -- with —
               autoCapitalize="none"
               autoCorrect={false}
-              autoFocus
               autoComplete="off"
             />
             {draftValue.length > 0 && (
@@ -194,6 +243,7 @@ export function StepHandle() {
                     <HandleSuggestions
                       suggestions={isHandleAvailable.suggestions}
                       onSelect={suggestion => {
+                        setHandleTouched(true)
                         setDraftValue(
                           suggestion.handle.slice(
                             0,

--- a/src/screens/Signup/StepHandle/index.tsx
+++ b/src/screens/Signup/StepHandle/index.tsx
@@ -160,7 +160,7 @@ export function StepHandle() {
       <View style={[a.gap_sm, a.pt_lg, a.z_10]}>
         <View>
           <TextField.LabelText>
-            <Trans>Name</Trans>
+            <Trans>Full Name</Trans>
           </TextField.LabelText>
           <TextField.Root
             isInvalid={!!state.error && state.errorField === 'display-name'}>
@@ -177,7 +177,7 @@ export function StepHandle() {
                   )
                 }
               }}
-              label={_(msg`Your name`)}
+              label={_(msg`Your full name`)}
               defaultValue={nameDraft}
               autoCapitalize="words"
               autoComplete="name"

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -190,7 +190,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                       {state.activeStep === SignupStep.INFO ? (
                         <Trans>Your account</Trans>
                       ) : state.activeStep === SignupStep.HANDLE ? (
-                        <Trans>Choose your username</Trans>
+                        <Trans>Your name and username</Trans>
                       ) : (
                         <Trans>Complete the challenge</Trans>
                       )}

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -38,6 +38,7 @@ type ErrorField =
   | 'handle'
   | 'password'
   | 'date-of-birth'
+  | 'display-name'
 
 export type SignupState = {
   analytics?: AnalyticsContextType
@@ -54,6 +55,7 @@ export type SignupState = {
   password: string
   inviteCode: string
   handle: string
+  displayName: string
 
   error: string
   errorField?: ErrorField
@@ -80,6 +82,7 @@ export type SignupAction =
   | {type: 'setDateOfBirth'; value: Date}
   | {type: 'setInviteCode'; value: string}
   | {type: 'setHandle'; value: string}
+  | {type: 'setDisplayName'; value: string}
   | {type: 'setError'; value: string; field?: ErrorField}
   | {type: 'clearError'}
   | {type: 'setIsLoading'; value: boolean}
@@ -100,6 +103,7 @@ export const initialState: SignupState = {
   email: '',
   password: '',
   handle: '',
+  displayName: '',
   inviteCode: '',
 
   error: '',
@@ -116,6 +120,7 @@ export const initialState: SignupState = {
     handle: 0,
     password: 0,
     'date-of-birth': 0,
+    'display-name': 0,
   },
   backgroundCount: 0,
 }
@@ -189,6 +194,10 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
     }
     case 'setHandle': {
       next.handle = a.value
+      break
+    }
+    case 'setDisplayName': {
+      next.displayName = a.value
       break
     }
     case 'setIsLoading': {
@@ -287,6 +296,14 @@ export function useSubmitSignup() {
           field: 'password',
         })
       }
+      if (!state.displayName.trim()) {
+        dispatch({type: 'setStep', value: SignupStep.HANDLE})
+        return dispatch({
+          type: 'setError',
+          value: l`Please enter your name.`,
+          field: 'display-name',
+        })
+      }
       if (!state.handle) {
         dispatch({type: 'setStep', value: SignupStep.HANDLE})
         return dispatch({
@@ -318,6 +335,7 @@ export function useSubmitSignup() {
             service: state.serviceUrl,
             email: state.email,
             handle: createFullHandle(state.handle, state.userDomain),
+            displayName: state.displayName.trim(),
             password: state.password,
             birthDate: state.dateOfBirth,
             inviteCode: state.inviteCode.trim(),
@@ -337,7 +355,7 @@ export function useSubmitSignup() {
          * Must happen last so that if the user has multiple tabs open and
          * createAccount fails, one tab is not stuck in onboarding — Eric
          */
-        onboardingDispatch({type: 'finish'})
+        onboardingDispatch({type: 'start'})
       } catch (err) {
         const e = err as Error
         let errMsg = e.toString()

--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -40,11 +40,10 @@ export function SignupQueued() {
     try {
       const res = await agent.com.atproto.temp.checkSignupQueue()
       if (res.data.activated) {
-        // ready to go, exchange the access token for a usable one
+        // ready to go, exchange the access token for a usable one and kick off onboarding
         await agent.sessionManager.refreshSession()
         if (!isSignupQueued(agent.session?.accessJwt)) {
-          // onboarding is skipped entirely, so mark it complete right away
-          onboardingDispatch({type: 'finish'})
+          onboardingDispatch({type: 'start'})
         }
       } else {
         // not ready, update UI

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -127,6 +127,7 @@ export async function createAgentAndCreateAccount(
     email,
     password,
     handle,
+    displayName,
     birthDate,
     inviteCode,
     verificationPhone,
@@ -136,6 +137,7 @@ export async function createAgentAndCreateAccount(
     email: string
     password: string
     handle: string
+    displayName?: string
     birthDate: Date
     inviteCode?: string
     verificationPhone?: string
@@ -176,13 +178,13 @@ export async function createAgentAndCreateAccount(
   const aa = prefetchAgeAssuranceServerData({agent})
 
   /*
-   * With onboarding skipped, the Home screen renders as soon as account
-   * creation resolves, and its preferences fetch calls getPreferences. If
-   * that runs before any savedFeeds pref exists on the server, @atproto/api
-   * writes back a following-only default, clobbering the brand defaults.
-   * So the feed seeding (and the brand follow, so the following feed is not
-   * empty on first render) must complete before we return. Failures are
-   * logged but do not block signup.
+   * The first getPreferences call after signup (which can happen as soon as
+   * the app shell renders) writes back a following-only savedFeeds default
+   * when no savedFeeds pref exists yet, clobbering the brand defaults. So
+   * the feed seeding (and the brand follow, so the following feed is not
+   * empty on first render) must complete before we return. This also covers
+   * users who abandon onboarding before its final save. Failures are logged
+   * but do not block signup.
    */
   if (IS_PROD_SERVICE(service)) {
     await Promise.allSettled([
@@ -230,7 +232,7 @@ export async function createAgentAndCreateAccount(
       networkRetry(3, () => {
         return agent.upsertProfile(prev => {
           const next: Un$Typed<AppBskyActorProfile.Record> = prev || {}
-          next.displayName = handle
+          next.displayName = displayName?.trim() || handle
           next.createdAt = createdAt
           return next
         })

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -176,8 +176,14 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         {session: utils.accountToSessionMetadata(account)},
       )
       addSessionDebugLog({type: 'method:end', method: 'login', account})
+      /*
+       * Onboarding should only ever appear right after signup. Reset it on
+       * login so stale persisted state (e.g. an interrupted onboarding on
+       * this device) does not re-trigger it.
+       */
+      onboardingDispatch({type: 'skip'})
     },
-    [ax, store, onAgentSessionChange, cancelPendingTask],
+    [ax, store, onAgentSessionChange, cancelPendingTask, onboardingDispatch],
   )
 
   const logoutCurrentAccount = useCallback<

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -16,6 +16,11 @@ export type SessionApiContext = {
       email: string
       password: string
       handle: string
+      /**
+       * The user's chosen display name, set on their profile right after the
+       * account is created. Falls back to the handle when empty.
+       */
+      displayName?: string
       birthDate: Date
       inviteCode?: string
       verificationPhone?: string

--- a/src/state/shell/onboarding.tsx
+++ b/src/state/shell/onboarding.tsx
@@ -114,15 +114,9 @@ export function isOnboardingActive() {
 }
 
 function compute(state: persisted.Schema['onboarding']): StateContext {
-  /*
-   * Onboarding is disabled entirely (issue #67) - users go straight into
-   * the app after signup. The persisted step is deliberately ignored so
-   * stale state written by older builds (or any stray 'start' dispatch)
-   * can never re-trigger the onboarding screens.
-   */
   return {
     ...state,
-    isActive: false,
-    isComplete: true,
+    isActive: state.step !== 'Home',
+    isComplete: state.step === 'Home',
   }
 }


### PR DESCRIPTION
## Summary

Rework of the onboarding removal (#75/#76/#79): instead of skipping onboarding entirely, we now collect the user's name during signup and keep a single onboarding screen for the profile picture.

### Signup: name + suggested username
- The username step is now "Your name and username": a required **Name** field sits above the username field.
- Typing a name live-suggests a handle (e.g. "John Smith" → `johnsmith`). Once the user edits the handle manually (or picks a server suggestion), the auto-fill stops.
- Next is disabled until a name is entered; a submit-time guard also catches empty names.
- The display name is saved on the profile at account creation ([src/state/session/agent.ts](src/state/session/agent.ts)) instead of the old behavior of defaulting it to the handle.

### Onboarding: profile picture only
- Onboarding is re-enabled (the force-disable in `compute()` is reverted) and starts right after signup, but is trimmed to a single step: the avatar picker (`StepProfile`). Interests, suggested accounts, starter packs, find-contacts, and the finish screen no longer render.
- The finishing side effects moved from the now-unused `StepFinished` screen into a new `useFinishOnboarding` hook, called from StepProfile's Continue button (with a saving spinner): avatar upload, starter-pack follows/feeds (when applicable), query invalidations, progress guide.
- The brand-account follow and default feed seeding remain at account creation (awaited, from #79) — they are no longer duplicated in the finish step, avoiding a double follow record.
- `login` now resets onboarding state, so stale persisted steps from old builds can only ever surface onboarding right after signup.
- The "Step N of M" indicator hides when there's a single step.

## Verification
- `pnpm typecheck` and eslint pass on all changed files.
- Verified on the web dev server: name field renders above username; typing "John Smith" prefills `johnsmith`; manual handle edits stop the sync; empty name disables Next (screenshot in session).
- E2E flows (`create-account.yml`, `onboarding.yml`) updated for the new field and single-step flow.
- Remaining manual check: fresh signup on coseeker.org → name+username → avatar step → Home with feeds pinned, @coseeker.com followed, profile showing the entered name and avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)