### PR TITLE
Pin brand default feeds when finishing onboarding

### DIFF
--- a/src/screens/Onboarding/useFinishOnboarding.ts
+++ b/src/screens/Onboarding/useFinishOnboarding.ts
@@ -103,28 +103,33 @@ export function useFinishOnboarding() {
         })(),
         (async () => {
           /*
-           * Default feeds are seeded at account creation; only rewrite them
-           * when starter-pack feeds need to be appended.
+           * Authoritatively pin the brand default feeds (brand feed +
+           * following), plus any starter-pack feeds. Feeds are also seeded at
+           * account creation, but that can be lost: if no savedFeedsPrefV2
+           * exists yet, the first getPreferences() synthesizes and persists a
+           * following-only default, permanently dropping the brand feed. This
+           * runs late (after the session is live) and unconditionally, so it
+           * reliably restores the brand feed regardless of that race.
            */
-          if (starterPack && starterPack.feeds?.length) {
-            const feedsToSave: AppBskyActorDefs.SavedFeed[] = [
-              {
-                ...DISCOVER_SAVED_FEED,
-                id: TID.nextStr(),
-              },
-              {
-                ...TIMELINE_SAVED_FEED,
-                id: TID.nextStr(),
-              },
-              ...starterPack.feeds.map(f => ({
-                type: 'feed',
-                value: f.uri,
-                pinned: true,
-                id: TID.nextStr(),
-              })),
-            ]
-            await agent.overwriteSavedFeeds(feedsToSave)
-          }
+          const feedsToSave: AppBskyActorDefs.SavedFeed[] = [
+            {
+              ...DISCOVER_SAVED_FEED,
+              id: TID.nextStr(),
+            },
+            {
+              ...TIMELINE_SAVED_FEED,
+              id: TID.nextStr(),
+            },
+            ...(starterPack?.feeds?.length
+              ? starterPack.feeds.map(f => ({
+                  type: 'feed',
+                  value: f.uri,
+                  pinned: true,
+                  id: TID.nextStr(),
+                }))
+              : []),
+          ]
+          await agent.overwriteSavedFeeds(feedsToSave)
         })(),
         (async () => {
           const {imageUri, imageMime} = profileStepResults


### PR DESCRIPTION
## Problem

New accounts land on Home showing only the **Following** tab (plus the "Feeds ✨" management tab) instead of the brand's default feed (CoSeeker/K4M2A) pinned first.

## Root cause

The brand feed reaches an account's `savedFeeds` preference **only** via the seed written at account creation ([src/state/session/agent.ts](src/state/session/agent.ts), gated by `IS_PROD_SERVICE`). If that seed is skipped or fails, the very first `getPreferences()` call in `@atproto/api` synthesizes a **following-only** default and **persists it** to the server. After that, `savedFeedsPrefV2` exists, so the migration never runs again — the following-only state is permanent.

`finishOnboarding` was only re-writing feeds when a starter pack was present, so nothing re-pinned the brand feed for a normal signup. (The pre-refactor `StepFinished` used to re-pin the brand defaults unconditionally, which is why feeds worked before the onboarding rework.)

Confirmed during investigation that the brand feed generator itself resolves fine (`isOnline: true`), so this is a missing-from-prefs problem, not a broken-feed problem.

## Fix

Make `finishOnboarding` ([src/screens/Onboarding/useFinishOnboarding.ts](src/screens/Onboarding/useFinishOnboarding.ts)) **always** overwrite saved feeds with the brand defaults (brand feed + following), appending any starter-pack feeds. It runs after the session is live and unconditionally (no `IS_PROD_SERVICE` gate), so it reliably overrides whatever the account-creation race left behind; the existing preferences-query invalidation then makes Home read the corrected feeds.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `eslint` passes on the changed file
- [ ] Fresh signup on coseeker.org lands on Home with the CoSeeker feed pinned first, then Following

Note: accounts already stuck on following-only won't self-heal (their `savedFeedsPrefV2` already exists); re-pin via Settings → Feeds or test with a fresh account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)